### PR TITLE
refactor: restructure into src layout, fix bugs, add GUI (v0.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Python build artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editors
+.vscode/
+.idea/
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,43 @@
 
 All notable changes to pdfextract are documented here.
 
+## [0.2.0] - 2026-04-29
+
+### Changed
+- Reorganised into a proper `src/pdfextract/` package layout (`parser.py`,
+  `extractor.py`, `schema.py`, `gui.py`) for clarity and installability.
+- `pyproject.toml` updated to use the `src` layout and expose a
+  `pdfextract-gui` console script entry point.
+- Version bumped to 0.2.0.
+
+### Added
+- **Tkinter GUI** (`pdfextract --gui` / `pdfextract-gui`): file picker, format
+  selection, max-pages spinbox, background-threaded extraction with progress
+  bar, output text area, save-as dialog, and per-extraction word/page summary.
+- `PDFParser` now traverses the `/Pages` object tree (catalog → pages node →
+  leaf pages) for correct page ordering, falling back to a linear xref scan
+  for malformed documents.
+- Support for PDF 1.5+ cross-reference streams in addition to classic xref
+  tables; `/Prev`-chained xref entries are merged with correct precedence.
+- `/Contents` arrays (multiple content streams per page) are now concatenated
+  before text extraction.
+- Hex-encoded strings (`<4865...>`) in TJ operator arrays are now decoded.
+- `ExtractionResult.to_json()` convenience method added.
+- `src/pdfextract/__main__.py` added so `python -m pdfextract` works.
+- 34 unit and integration tests covering data models, string decoders,
+  stream parsing, and end-to-end extraction from programmatically generated
+  minimal PDFs.
+
+### Fixed
+- `src/pdfextract/__init__.py` previously imported from non-existent
+  `.extractor` and `.schema` submodules, causing `ImportError` on import.
+- `_find_xref_offset` now anchors the regex to `%%EOF` first before falling
+  back, avoiding false matches in binary content.
+- Octal escape sequences in literal strings longer than three digits now
+  consume exactly three digits per the PDF specification.
+
 ## [0.1.0] - 2024-01-15
 
 ### Added
-- Initial release of PDFExtract
-- Text extraction with reading-order reconstruction for single and multi-column layouts
-- Rule-based table detection with CSV and pandas DataFrame export
-- Figure bounding-box detection and captioned image cropping
-- Heuristic section header and metadata (title, authors, abstract) parsing
-- Batch processing CLI with glob pattern input support
-- Output formats: plain text, JSON (structured), and Markdown
-- Optional pdfplumber and pymupdf backends selectable at runtime
-- Unit tests covering extraction accuracy on sample academic PDFs
-- README with installation, CLI usage, and Python API reference
+- Initial release: pure-Python PDF parser, BT/ET text extraction, JSON/
+  Markdown/text output, CLI (`pdfextract`).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
   - family-names: Deshmukh
     given-names: V.A.
     alias: vdeshmukh203
-version: 0.1.0
-date-released: "2025-01-01"
+version: 0.2.0
+date-released: "2026-04-29"
 url: "https://github.com/vdeshmukh203/pdfextract"
 license: MIT

--- a/paper.md
+++ b/paper.md
@@ -1,12 +1,12 @@
 ---
-title: 'pdfextract: Structured extraction of text, tables, and figures from scientific PDF documents'
+title: 'pdfextract: A pure-Python tool for structured text and metadata extraction from PDF files'
 tags:
   - Python
   - PDF
   - extraction
-  - NLP
-  - scientific-computing
   - text-mining
+  - scientific-computing
+  - reproducibility
 authors:
   - name: Vaibhav Deshmukh
     orcid: 0000-0001-6745-7062
@@ -14,20 +14,38 @@ authors:
 affiliations:
   - name: Independent Researcher, Nagpur, India
     index: 1
-date: 23 April 2026
+date: 29 April 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-`pdfextract` is a Python library and command-line tool for structured extraction of content from scientific PDF documents. It combines PDF parsing (via `pdfminer.six`), table detection (via heuristic whitespace analysis and `camelot`), and figure boundary detection (via bounding-box analysis of non-text PDF objects) to produce structured output in JSON or Markdown format. Extracted content includes section-segmented body text, tables as pandas DataFrames, figure captions, and metadata (title, authors, abstract, DOI). `pdfextract` is designed for batch processing of paper corpora in systematic review and meta-analysis pipelines.
+`pdfextract` is a pure-Python library and command-line tool for extracting structured text and metadata from PDF files without requiring any external binaries or native libraries. It implements a self-contained PDF reader that parses cross-reference tables (including the PDF 1.5+ cross-reference stream format), traverses the page-object tree, decodes FlateDecode content streams, and recovers text from BT/ET operator blocks, handling both PDF literal strings and hex-encoded strings. Extracted content is returned as structured Python objects and can be serialised to plain text, Markdown, or JSON. An optional Tk-based graphical interface, launched via `pdfextract --gui`, provides interactive file selection, format switching, and output saving without additional dependencies beyond the Python standard library.
 
 # Statement of Need
 
-Scientific text mining pipelines require reliable extraction of structured content from PDF documents, but existing tools either require commercial licences, lack section-awareness, or produce poorly structured output that requires extensive post-processing [@gao2023reproducibility]. `pdfextract` targets the research workflow of processing hundreds to thousands of papers: it provides a batch mode, consistent JSON output schema, and graceful degradation when content cannot be reliably extracted rather than silently producing malformed output. The structured output integrates directly with downstream NLP tools, enabling reproducible corpus construction for meta-analyses and systematic literature reviews [@stodden2016enhancing; @pineau2021improving].
+Scientific text-mining pipelines require reliable extraction of text from PDF documents, but many existing tools impose external binary dependencies (e.g., poppler, ghostscript) that complicate reproducible environment setup in high-performance-computing clusters and containerised workflows [@gao2023reproducibility]. Other tools produce loosely structured output that requires substantial post-processing before downstream NLP can be applied. `pdfextract` addresses these constraints by:
+
+1. **Zero non-standard dependencies.** The library relies exclusively on the Python standard library (`re`, `zlib`, `json`, `tkinter`), making it trivially installable via `pip` in any Python 3.8+ environment with no OS-level packages.
+2. **Structured output schema.** Every extraction run returns an `ExtractionResult` object with per-page `PageResult` records (page number, text, word count, character count), document-level metadata fields (Title, Author, Subject, Keywords, Creator, Producer, CreationDate), and a list of non-fatal parse warnings. This consistent schema integrates directly into corpus-construction pipelines for systematic reviews and meta-analyses [@stodden2016enhancing; @pineau2021improving].
+3. **Graceful degradation.** Encrypted, malformed, or truncated PDFs return partial results with structured error messages rather than raising unhandled exceptions, enabling robust batch processing of heterogeneous corpora.
+4. **Multiple output formats.** Text, Markdown, and JSON outputs are supported both from the Python API and the CLI, and a GUI mode provides an accessible interface for researchers unfamiliar with the command line.
+
+## Limitations
+
+`pdfextract` operates on the raw byte-level representation of a PDF and therefore has inherent limitations. Reading order is determined by the order in which text operators appear in the content stream, which may not match the visual reading order for multi-column layouts or complex typeset documents. Encrypted PDFs, scanned (image-only) PDFs, and documents using non-standard font encodings (e.g., CID fonts with custom CMap tables) will yield little or no extracted text. Users requiring these capabilities should consider tools such as `pdfminer.six` [@pdfminer] or `pypdf` [@pypdf] as complements.
+
+# Implementation
+
+The library is organised as a `src`-layout Python package (`src/pdfextract/`) with four modules:
+
+- **`parser.py`** — `PDFParser` handles all binary I/O: locating the `startxref` offset, parsing classic xref tables and PDF 1.5+ xref streams, recursively following `/Prev` chains, traversing the `/Pages` object tree, resolving indirect object references, decompressing FlateDecode streams, and extracting the PDF Info dictionary.
+- **`extractor.py`** — `PDFExtractor` orchestrates a full extraction run, delegating to `PDFParser` and applying `_extract_text_from_stream` (BT/ET block scanning) to each page content stream. The public `extract_pdf()` function wraps `PDFExtractor` for one-shot use.
+- **`schema.py`** — `PageResult` and `ExtractionResult` dataclasses hold the structured output and provide `to_dict()`, `to_markdown()`, and `to_json()` serialisers.
+- **`gui.py`** — `PDFExtractGUI` is a Tk application that runs extraction on a background thread to keep the interface responsive, displays a progress indicator, and provides file-open and save-as dialogs.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for drafting portions of this manuscript and for code review. All scientific claims and design decisions are the author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfextract"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pure-Python structured text and metadata extractor for PDF files"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,7 +21,8 @@ classifiers = [
 ]
 
 [project.scripts]
-pdfextract = "pdfextract:_cli"
+pdfextract = "pdfextract.extractor:_cli"
+pdfextract-gui = "pdfextract.gui:_gui"
 
-[tool.setuptools]
-py-modules = ["pdfextract"]
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/pdfextract/__init__.py
+++ b/src/pdfextract/__init__.py
@@ -1,17 +1,36 @@
 """
-pdfextract: Structured scientific PDF content extraction tool.
+pdfextract: Pure-Python structured text and metadata extractor for PDF files.
 
-Parses scientific PDF documents and extracts structured content: sections,
-abstracts, figures, tables, captions, equations, citations, and metadata.
-Output is emitted as structured JSON, enabling downstream text mining,
-dataset construction, and reproducible scientific content analysis pipelines.
+Reads cross-reference tables (classic xref and PDF 1.5+ xref streams),
+traverses the page tree, decodes content streams, and outputs plain text,
+Markdown, or JSON. Falls back gracefully on malformed PDFs. An optional
+Tk-based graphical interface is available via ``pdfextract --gui``.
+
+Typical usage::
+
+    from pdfextract import extract_pdf, PDFExtractor
+
+    # One-shot convenience wrapper
+    text = extract_pdf("paper.pdf")
+
+    # Full result object with per-page data and metadata
+    result = PDFExtractor("paper.pdf").extract()
+    print(result.word_count, result.metadata)
 """
+from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .extractor import PDFExtractor
-from .schema import ExtractionResult
+from .extractor import PDFExtractor, extract_pdf
+from .parser import PDFParseError
+from .schema import ExtractionResult, PageResult
 
-__all__ = ["PDFExtractor", "ExtractionResult"]
+__all__ = [
+    "PDFExtractor",
+    "ExtractionResult",
+    "PageResult",
+    "PDFParseError",
+    "extract_pdf",
+]

--- a/src/pdfextract/__main__.py
+++ b/src/pdfextract/__main__.py
@@ -1,0 +1,4 @@
+"""Allow ``python -m pdfextract`` as an alternative to the ``pdfextract`` CLI."""
+from .extractor import _cli
+
+_cli()

--- a/src/pdfextract/extractor.py
+++ b/src/pdfextract/extractor.py
@@ -1,0 +1,205 @@
+"""PDF text extractor, public API, and CLI entry point."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Optional
+
+from .parser import PDFParseError, PDFParser, _decode_hex_string, _decode_literal_string
+from .schema import ExtractionResult, PageResult
+
+# ---------------------------------------------------------------------------
+# Content-stream text extraction
+# ---------------------------------------------------------------------------
+
+_BT_ET = re.compile(rb"BT(.+?)ET", re.DOTALL)
+_LITERAL_STR = re.compile(rb"\(([^)\\]*(?:\\.[^)\\]*)*)\)")
+_HEX_STR = re.compile(rb"<([0-9a-fA-F\s]+)>")
+
+
+def _strings_from_block(block: bytes) -> List[str]:
+    """Extract all text strings from a single BT…ET block."""
+    parts: List[str] = []
+
+    # Collect raw positions and strings, then sort by byte position so that
+    # TJ arrays and standalone Tj calls are interleaved in stream order.
+    tokens: List[tuple] = []  # (start_pos, text)
+
+    for m in _LITERAL_STR.finditer(block):
+        tokens.append((m.start(), _decode_literal_string(m.group(1))))
+
+    # Hex strings that appear inside TJ arrays
+    for tj_m in re.finditer(rb"\[([^\]]+)\]\s*TJ", block):
+        inner = tj_m.group(1)
+        for hm in _HEX_STR.finditer(inner):
+            tokens.append((tj_m.start(), _decode_hex_string(hm.group(1))))
+
+    tokens.sort(key=lambda t: t[0])
+    return [text for _, text in tokens]
+
+
+def _extract_text_from_stream(stream: bytes) -> str:
+    """Pull all text from a PDF content stream via BT/ET block parsing."""
+    parts: List[str] = []
+    for bt_block in _BT_ET.finditer(stream):
+        block_parts = _strings_from_block(bt_block.group(1))
+        parts.extend(block_parts)
+    return " ".join(p.strip() for p in parts if p.strip())
+
+
+# ---------------------------------------------------------------------------
+# Public extractor class
+# ---------------------------------------------------------------------------
+
+class PDFExtractor:
+    """Extract text and metadata from a PDF file without external binaries.
+
+    Parameters
+    ----------
+    path:
+        Path to the PDF file.
+    max_pages:
+        Stop after this many pages; ``0`` means extract all pages.
+    """
+
+    def __init__(self, path: str, max_pages: int = 0) -> None:
+        self.path = Path(path)
+        self.max_pages = max_pages
+
+    def extract(self) -> ExtractionResult:
+        """Run extraction and return an :class:`~pdfextract.ExtractionResult`."""
+        result = ExtractionResult(source=self.path.name, page_count=0)
+        parser = PDFParser(self.path)
+
+        try:
+            parser.load()
+        except PDFParseError as exc:
+            result.errors.append(f"load error: {exc}")
+            return result
+        except OSError as exc:
+            result.errors.append(f"file error: {exc}")
+            return result
+
+        try:
+            result.metadata = parser.get_metadata()
+        except Exception as exc:  # noqa: BLE001
+            result.errors.append(f"metadata error: {exc}")
+
+        try:
+            page_streams = parser.get_page_content_streams()
+        except Exception as exc:  # noqa: BLE001
+            result.errors.append(f"page listing error: {exc}")
+            return result
+
+        pages: List[PageResult] = []
+        for page_num, stream in page_streams:
+            if self.max_pages and page_num > self.max_pages:
+                break
+            try:
+                text = _extract_text_from_stream(stream)
+            except Exception as exc:  # noqa: BLE001
+                result.errors.append(f"page {page_num} text error: {exc}")
+                text = ""
+            pages.append(PageResult(page_number=page_num, text=text))
+
+        result.pages = pages
+        result.page_count = len(pages)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Convenience function
+# ---------------------------------------------------------------------------
+
+def extract_pdf(
+    path: str,
+    output_format: str = "text",
+    output_path: Optional[str] = None,
+    max_pages: int = 0,
+) -> str:
+    """Extract text from *path* and return it as a string.
+
+    Parameters
+    ----------
+    path:
+        Input PDF path.
+    output_format:
+        ``"text"`` (default), ``"markdown"``, or ``"json"``.
+    output_path:
+        If provided, write the output to this file path.
+    max_pages:
+        Maximum number of pages to process; ``0`` means all pages.
+
+    Returns
+    -------
+    str
+        Extracted content in the requested format.
+    """
+    extractor = PDFExtractor(path, max_pages=max_pages)
+    result = extractor.extract()
+
+    if output_format == "json":
+        out = result.to_json()
+    elif output_format == "markdown":
+        out = result.to_markdown()
+    else:
+        out = result.full_text
+
+    if output_path:
+        Path(output_path).write_text(out, encoding="utf-8")
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _cli() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="pdfextract",
+        description="Extract structured text and metadata from PDF files.",
+    )
+    parser.add_argument("input", nargs="?", help="Path to input PDF file.")
+    parser.add_argument("-o", "--output", default=None, help="Output file path.")
+    parser.add_argument(
+        "-f", "--format",
+        choices=["text", "markdown", "json"],
+        default="text",
+        dest="fmt",
+        help="Output format (default: text).",
+    )
+    parser.add_argument(
+        "-p", "--max-pages",
+        type=int,
+        default=0,
+        help="Maximum pages to extract (0 = all).",
+    )
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help="Launch the graphical user interface.",
+    )
+    args = parser.parse_args()
+
+    if args.gui:
+        from .gui import _gui
+        _gui()
+        return
+
+    if not args.input:
+        parser.print_help()
+        return
+
+    out = extract_pdf(
+        args.input,
+        output_format=args.fmt,
+        output_path=args.output,
+        max_pages=args.max_pages,
+    )
+    if args.output:
+        print(f"Written to {args.output}")
+    else:
+        print(out)

--- a/src/pdfextract/gui.py
+++ b/src/pdfextract/gui.py
@@ -1,0 +1,234 @@
+"""Tkinter graphical user interface for pdfextract.
+
+Launched via ``pdfextract --gui`` or the ``pdfextract-gui`` console script.
+Requires Tk (ships with CPython; install ``python3-tk`` on Linux if absent).
+"""
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+from typing import Optional
+
+from .extractor import PDFExtractor
+from .schema import ExtractionResult
+
+
+class PDFExtractGUI:
+    """Main application window for the pdfextract GUI."""
+
+    _FORMATS = ("text", "markdown", "json")
+    _PAD = {"padx": 10, "pady": 4}
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("pdfextract")
+        self.root.geometry("960x720")
+        self.root.minsize(720, 520)
+        self._result: Optional[ExtractionResult] = None
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        self._build_input_bar()
+        self._build_options_bar()
+        self._build_action_bar()
+        self._build_progress()
+        self._build_output_area()
+        self._build_status_bar()
+
+    def _build_input_bar(self) -> None:
+        frame = ttk.LabelFrame(self.root, text="PDF file", padding=8)
+        frame.pack(fill=tk.X, **self._PAD)
+
+        self.path_var = tk.StringVar()
+        entry = ttk.Entry(frame, textvariable=self.path_var)
+        entry.pack(side=tk.LEFT, expand=True, fill=tk.X)
+        entry.bind("<Return>", lambda _: self._extract_async())
+
+        ttk.Button(frame, text="Browse…", command=self._browse).pack(
+            side=tk.LEFT, padx=(6, 0)
+        )
+
+    def _build_options_bar(self) -> None:
+        frame = ttk.LabelFrame(self.root, text="Options", padding=8)
+        frame.pack(fill=tk.X, **self._PAD)
+
+        ttk.Label(frame, text="Output format:").grid(
+            row=0, column=0, sticky=tk.W, padx=(0, 6)
+        )
+        self.fmt_var = tk.StringVar(value="text")
+        for col, fmt in enumerate(self._FORMATS, start=1):
+            ttk.Radiobutton(
+                frame, text=fmt.capitalize(), variable=self.fmt_var, value=fmt
+            ).grid(row=0, column=col, padx=4, sticky=tk.W)
+
+        ttk.Label(frame, text="Max pages (0 = all):").grid(
+            row=0, column=10, padx=(20, 4), sticky=tk.W
+        )
+        self.max_pages_var = tk.IntVar(value=0)
+        ttk.Spinbox(
+            frame,
+            from_=0,
+            to=9999,
+            textvariable=self.max_pages_var,
+            width=7,
+        ).grid(row=0, column=11, sticky=tk.W)
+
+    def _build_action_bar(self) -> None:
+        frame = ttk.Frame(self.root)
+        frame.pack(fill=tk.X, **self._PAD)
+
+        self.extract_btn = ttk.Button(
+            frame, text="Extract", command=self._extract_async
+        )
+        self.extract_btn.pack(side=tk.LEFT)
+        ttk.Button(frame, text="Save…", command=self._save).pack(
+            side=tk.LEFT, padx=(6, 0)
+        )
+        ttk.Button(frame, text="Clear", command=self._clear).pack(
+            side=tk.LEFT, padx=(6, 0)
+        )
+
+    def _build_progress(self) -> None:
+        self.progress = ttk.Progressbar(self.root, mode="indeterminate")
+        self.progress.pack(fill=tk.X, padx=10, pady=(0, 2))
+
+    def _build_output_area(self) -> None:
+        frame = ttk.LabelFrame(self.root, text="Output", padding=4)
+        frame.pack(fill=tk.BOTH, expand=True, **self._PAD)
+
+        self.text_area = scrolledtext.ScrolledText(
+            frame,
+            wrap=tk.WORD,
+            state=tk.DISABLED,
+            font=("Courier New", 10),
+            relief=tk.FLAT,
+            background="#fafafa",
+        )
+        self.text_area.pack(fill=tk.BOTH, expand=True)
+
+    def _build_status_bar(self) -> None:
+        frame = ttk.Frame(self.root, relief=tk.SUNKEN)
+        frame.pack(fill=tk.X, side=tk.BOTTOM)
+
+        self.info_var = tk.StringVar(value="")
+        self.status_var = tk.StringVar(value="Ready.")
+
+        ttk.Label(frame, textvariable=self.info_var, anchor=tk.W).pack(
+            side=tk.LEFT, padx=6
+        )
+        ttk.Label(frame, textvariable=self.status_var, anchor=tk.E).pack(
+            side=tk.RIGHT, padx=6
+        )
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select PDF file",
+            filetypes=[("PDF files", "*.pdf"), ("All files", "*.*")],
+        )
+        if path:
+            self.path_var.set(path)
+
+    def _extract_async(self) -> None:
+        path = self.path_var.get().strip()
+        if not path:
+            messagebox.showwarning("No file selected", "Please choose a PDF file first.")
+            return
+        self.extract_btn.configure(state=tk.DISABLED)
+        self.progress.start(10)
+        self.status_var.set("Extracting…")
+        self.info_var.set("")
+        threading.Thread(
+            target=self._do_extract, args=(path,), daemon=True
+        ).start()
+
+    def _do_extract(self, path: str) -> None:
+        try:
+            extractor = PDFExtractor(path, max_pages=self.max_pages_var.get())
+            result = extractor.extract()
+            self._result = result
+            fmt = self.fmt_var.get()
+            if fmt == "json":
+                content = result.to_json()
+            elif fmt == "markdown":
+                content = result.to_markdown()
+            else:
+                content = result.full_text or "(No text could be extracted)"
+            info = f"Pages: {result.page_count}  |  Words: {result.word_count}"
+            if result.errors:
+                info += f"  |  Warnings: {len(result.errors)}"
+            self.root.after(0, self._on_success, content, info, result.errors)
+        except Exception as exc:  # noqa: BLE001
+            self.root.after(0, self._on_error, str(exc))
+
+    def _on_success(self, content: str, info: str, errors: list) -> None:
+        self.progress.stop()
+        self.extract_btn.configure(state=tk.NORMAL)
+        self.status_var.set("Done.")
+        self.info_var.set(info)
+        self._set_text(content)
+        if errors:
+            messagebox.showwarning(
+                "Extraction warnings",
+                "One or more issues occurred during extraction:\n\n"
+                + "\n".join(f"• {e}" for e in errors[:8]),
+            )
+
+    def _on_error(self, msg: str) -> None:
+        self.progress.stop()
+        self.extract_btn.configure(state=tk.NORMAL)
+        self.status_var.set("Error.")
+        messagebox.showerror("Extraction failed", msg)
+
+    def _set_text(self, content: str) -> None:
+        self.text_area.configure(state=tk.NORMAL)
+        self.text_area.delete("1.0", tk.END)
+        self.text_area.insert(tk.END, content)
+        self.text_area.configure(state=tk.DISABLED)
+
+    def _save(self) -> None:
+        content = self.text_area.get("1.0", tk.END).strip()
+        if not content:
+            messagebox.showinfo("Nothing to save", "Run an extraction first.")
+            return
+        fmt = self.fmt_var.get()
+        ext_map = {"text": ".txt", "markdown": ".md", "json": ".json"}
+        path = filedialog.asksaveasfilename(
+            defaultextension=ext_map.get(fmt, ".txt"),
+            filetypes=[
+                ("Text files", "*.txt"),
+                ("Markdown files", "*.md"),
+                ("JSON files", "*.json"),
+                ("All files", "*.*"),
+            ],
+        )
+        if path:
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            self.status_var.set(f"Saved → {path}")
+
+    def _clear(self) -> None:
+        self._set_text("")
+        self.info_var.set("")
+        self.status_var.set("Ready.")
+        self._result = None
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def _gui() -> None:
+    """Launch the pdfextract graphical interface."""
+    PDFExtractGUI().run()

--- a/src/pdfextract/parser.py
+++ b/src/pdfextract/parser.py
@@ -1,0 +1,412 @@
+"""Low-level PDF binary parser.
+
+Handles PDF 1.x classic cross-reference tables and PDF 1.5+ cross-reference
+streams. Traverses the page tree to return content streams in page order.
+No external binary dependencies are required.
+"""
+from __future__ import annotations
+
+import re
+import zlib
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+
+class PDFParseError(Exception):
+    """Raised when a PDF file cannot be parsed."""
+
+
+# ---------------------------------------------------------------------------
+# String decoders
+# ---------------------------------------------------------------------------
+
+def _decode_flate(raw: bytes) -> bytes:
+    """Decompress FlateDecode data, trying with and without the zlib header."""
+    for wbits in (15, -15):
+        try:
+            return zlib.decompress(raw, wbits)
+        except zlib.error:
+            pass
+    return raw
+
+
+def _decode_hex_string(s: bytes) -> str:
+    """Decode a PDF hex string (without angle brackets), e.g. b'48656c6c6f'."""
+    hex_data = re.sub(rb"\s+", b"", s)
+    if len(hex_data) % 2:
+        hex_data += b"0"
+    try:
+        return bytes.fromhex(hex_data.decode("ascii", errors="replace")).decode(
+            "latin-1", errors="replace"
+        )
+    except ValueError:
+        return ""
+
+
+def _decode_literal_string(s: bytes) -> str:
+    """Decode a PDF literal string (without surrounding parentheses)."""
+    out: List[str] = []
+    i = 0
+    while i < len(s):
+        c = s[i : i + 1]
+        if c == b"\\":
+            i += 1
+            if i >= len(s):
+                break
+            nc = s[i : i + 1]
+            if nc == b"n":
+                out.append("\n")
+            elif nc == b"r":
+                out.append("\r")
+            elif nc == b"t":
+                out.append("\t")
+            elif nc == b"b":
+                out.append("\b")
+            elif nc == b"f":
+                out.append("\f")
+            elif nc in (b"(", b")", b"\\"):
+                out.append(nc.decode("latin-1"))
+            elif b"0" <= nc <= b"7":
+                octal = s[i : i + 3]
+                try:
+                    out.append(chr(int(octal, 8)))
+                    i += len(octal) - 1
+                except ValueError:
+                    out.append(nc.decode("latin-1", errors="replace"))
+            else:
+                out.append(nc.decode("latin-1", errors="replace"))
+        else:
+            out.append(c.decode("latin-1", errors="replace"))
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# PDFParser
+# ---------------------------------------------------------------------------
+
+class PDFParser:
+    """Read and parse a PDF file, exposing page content streams and metadata.
+
+    Parameters
+    ----------
+    path:
+        Path to the PDF file to open.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._data: bytes = b""
+        self._xref: Dict[int, int] = {}
+        self._trailer: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """Read and validate the file; build the cross-reference index."""
+        self._data = self.path.read_bytes()
+        if not self._data.startswith(b"%PDF"):
+            raise PDFParseError(f"Not a PDF file: {self.path}")
+        xref_offset = self._find_xref_offset()
+        self._xref, self._trailer = self._parse_xref_chain(xref_offset, set())
+
+    def get_metadata(self) -> Dict[str, str]:
+        """Return selected PDF Info dictionary fields that are non-empty."""
+        metadata: Dict[str, str] = {}
+        info_ref = self._trailer.get("Info")
+        if info_ref is None:
+            return metadata
+        body = self._get_object_body(int(info_ref))
+        if body is None:
+            return metadata
+
+        fields = [
+            "Title", "Author", "Subject", "Keywords",
+            "Creator", "Producer", "CreationDate", "ModDate",
+        ]
+        for f in fields:
+            key = f.encode()
+            lit = re.search(rb"/" + key + rb"\s*\(([^)\\]*(?:\\.[^)\\]*)*)\)", body)
+            if lit:
+                metadata[f] = _decode_literal_string(lit.group(1))
+                continue
+            hex_m = re.search(rb"/" + key + rb"\s*<([0-9a-fA-F\s]*)>", body)
+            if hex_m:
+                metadata[f] = _decode_hex_string(hex_m.group(1))
+
+        return {k: v for k, v in metadata.items() if v.strip()}
+
+    def get_page_content_streams(self) -> List[Tuple[int, bytes]]:
+        """Return ``(page_number, content_bytes)`` for every page, in order.
+
+        Traverses the ``/Pages`` tree from the document catalog.  Falls back
+        to a linear scan of all cross-referenced objects if the tree cannot
+        be walked.
+        """
+        pages: List[Tuple[int, bytes]] = []
+
+        root_ref = self._trailer.get("Root")
+        if root_ref is not None:
+            page_ids = self._collect_page_ids(int(root_ref))
+            if page_ids:
+                for page_num, obj_id in enumerate(page_ids, start=1):
+                    body = self._get_object_body(obj_id)
+                    if body is None:
+                        continue
+                    stream = self._content_stream_for_page(body)
+                    if stream is not None:
+                        pages.append((page_num, stream))
+                return pages
+
+        # Fallback: scan cross-reference table for /Type /Page objects
+        page_num = 0
+        for obj_id in sorted(self._xref.keys()):
+            body = self._get_object_body(obj_id)
+            if body is None:
+                continue
+            if re.search(rb"/Type\s*/Page\b", body):
+                stream = self._content_stream_for_page(body)
+                if stream is not None:
+                    page_num += 1
+                    pages.append((page_num, stream))
+        return pages
+
+    # ------------------------------------------------------------------
+    # Cross-reference parsing
+    # ------------------------------------------------------------------
+
+    def _find_xref_offset(self) -> int:
+        tail = self._data[-2048:]
+        m = re.search(rb"startxref\s+(\d+)\s*%%EOF", tail)
+        if not m:
+            m = re.search(rb"startxref\s+(\d+)", tail)
+        if not m:
+            raise PDFParseError("startxref not found")
+        return int(m.group(1))
+
+    def _parse_xref_chain(
+        self,
+        offset: int,
+        seen: Set[int],
+    ) -> Tuple[Dict[int, int], Dict[str, Any]]:
+        """Recursively parse linked xref tables/streams; later entries win."""
+        if offset in seen:
+            return {}, {}
+        seen.add(offset)
+
+        chunk = self._data[offset : offset + 65536]
+        if re.match(rb"\s*xref", chunk):
+            offsets, trailer = self._parse_classic_xref(chunk)
+        else:
+            offsets, trailer = self._parse_xref_stream(offset)
+
+        prev = trailer.get("Prev")
+        if prev is not None:
+            prev_offsets, prev_trailer = self._parse_xref_chain(int(prev), seen)
+            # Earlier xref has lower priority — only fill missing entries
+            for k, v in prev_offsets.items():
+                offsets.setdefault(k, v)
+            for k, v in prev_trailer.items():
+                trailer.setdefault(k, v)
+
+        return offsets, trailer
+
+    def _parse_classic_xref(
+        self, chunk: bytes
+    ) -> Tuple[Dict[int, int], Dict[str, Any]]:
+        """Parse a traditional `xref` table plus its `trailer` dictionary."""
+        offsets: Dict[int, int] = {}
+        text = chunk.decode("latin-1", errors="replace")
+        lines = text.splitlines()
+        i = 0
+        if i < len(lines) and lines[i].strip() == "xref":
+            i += 1
+        while i < len(lines):
+            m = re.match(r"(\d+)\s+(\d+)", lines[i].strip())
+            if not m:
+                break
+            first_obj, count = int(m.group(1)), int(m.group(2))
+            i += 1
+            for j in range(count):
+                if i >= len(lines):
+                    break
+                parts = lines[i].strip().split()
+                i += 1
+                if len(parts) >= 3 and parts[2] == "n":
+                    offsets[first_obj + j] = int(parts[0])
+
+        trailer = self._parse_trailer_dict(chunk)
+        return offsets, trailer
+
+    def _parse_xref_stream(
+        self, offset: int
+    ) -> Tuple[Dict[int, int], Dict[str, Any]]:
+        """Parse a PDF 1.5+ cross-reference stream object."""
+        offsets: Dict[int, int] = {}
+        try:
+            _, body = self._parse_obj_at(offset)
+        except PDFParseError:
+            return offsets, {}
+
+        stream_bytes = self._extract_stream_bytes(body)
+        if stream_bytes is None:
+            return offsets, {}
+
+        # Parse /W and /Index from the stream dictionary header
+        hdr = body[: body.find(b"stream")]
+        w_m = re.search(rb"/W\s*\[([^\]]+)\]", hdr)
+        idx_m = re.search(rb"/Index\s*\[([^\]]+)\]", hdr)
+        size_m = re.search(rb"/Size\s+(\d+)", hdr)
+
+        if not w_m:
+            return offsets, self._parse_trailer_dict(hdr)
+
+        w = [int(x) for x in w_m.group(1).split()]
+        if len(w) != 3:
+            return offsets, {}
+        w0, w1, w2 = w
+        entry_size = w0 + w1 + w2
+
+        size = int(size_m.group(1)) if size_m else 0
+        if idx_m:
+            idx = [int(x) for x in idx_m.group(1).split()]
+        else:
+            idx = [0, size]
+
+        pos = 0
+        seg = 0
+        while seg + 1 < len(idx):
+            first_obj = idx[seg]
+            count = idx[seg + 1]
+            seg += 2
+            for j in range(count):
+                if pos + entry_size > len(stream_bytes):
+                    break
+                entry = stream_bytes[pos : pos + entry_size]
+                pos += entry_size
+                type_field = (
+                    int.from_bytes(entry[:w0], "big") if w0 else 1
+                )
+                f1 = (
+                    int.from_bytes(entry[w0 : w0 + w1], "big") if w1 else 0
+                )
+                if type_field == 1:  # in-use uncompressed object
+                    offsets[first_obj + j] = f1
+
+        return offsets, self._parse_trailer_dict(hdr)
+
+    def _parse_trailer_dict(self, data: bytes) -> Dict[str, Any]:
+        """Extract /Root, /Info, /Prev, /Size from raw bytes."""
+        result: Dict[str, Any] = {}
+        for key in ("Root", "Info"):
+            m = re.search(rb"/" + key.encode() + rb"\s+(\d+)\s+\d+\s+R", data)
+            if m:
+                result[key] = int(m.group(1))
+        for key in ("Prev", "Size"):
+            m = re.search(rb"/" + key.encode() + rb"\s+(\d+)", data)
+            if m:
+                result[key] = int(m.group(1))
+        return result
+
+    # ------------------------------------------------------------------
+    # Object access
+    # ------------------------------------------------------------------
+
+    def _parse_obj_at(self, offset: int) -> Tuple[int, bytes]:
+        chunk = self._data[offset : offset + 65536]
+        m = re.search(rb"(\d+)\s+\d+\s+obj", chunk)
+        if not m:
+            raise PDFParseError(f"obj marker not found at offset {offset}")
+        start = m.end()
+        end_m = re.search(rb"endobj", chunk[start:])
+        body = chunk[start : start + (end_m.start() if end_m else len(chunk[start:]))]
+        return int(m.group(1)), body
+
+    def _get_object_body(self, obj_id: int) -> Optional[bytes]:
+        if obj_id not in self._xref:
+            return None
+        try:
+            _, body = self._parse_obj_at(self._xref[obj_id])
+            return body
+        except PDFParseError:
+            return None
+
+    def _extract_stream_bytes(self, obj_body: bytes) -> Optional[bytes]:
+        """Extract and decompress the data stream from an object body."""
+        m = re.search(rb"stream\r?\n", obj_body)
+        if not m:
+            return None
+        start = m.end()
+        end_m = re.search(rb"\r?\nendstream", obj_body[start:])
+        raw = obj_body[start : start + (end_m.start() if end_m else len(obj_body))]
+        if b"FlateDecode" in obj_body[:start]:
+            raw = _decode_flate(raw)
+        return raw
+
+    def get_stream(self, obj_id: int) -> Optional[bytes]:
+        body = self._get_object_body(obj_id)
+        return None if body is None else self._extract_stream_bytes(body)
+
+    # ------------------------------------------------------------------
+    # Page tree traversal
+    # ------------------------------------------------------------------
+
+    def _collect_page_ids(self, root_ref: int) -> List[int]:
+        """Walk the /Pages tree from the document catalog; return page obj IDs."""
+        catalog = self._get_object_body(root_ref)
+        if catalog is None:
+            return []
+        m = re.search(rb"/Pages\s+(\d+)\s+\d+\s+R", catalog)
+        if not m:
+            return []
+        page_ids: List[int] = []
+        self._walk_pages(int(m.group(1)), page_ids, set())
+        return page_ids
+
+    def _walk_pages(
+        self, node_id: int, page_ids: List[int], visited: Set[int]
+    ) -> None:
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        body = self._get_object_body(node_id)
+        if body is None:
+            return
+        type_m = re.search(rb"/Type\s*/(\w+)", body)
+        if not type_m:
+            return
+        node_type = type_m.group(1)
+        if node_type == b"Page":
+            page_ids.append(node_id)
+        elif node_type == b"Pages":
+            kids_m = re.search(rb"/Kids\s*\[([^\]]+)\]", body)
+            if kids_m:
+                for ref_m in re.finditer(rb"(\d+)\s+\d+\s+R", kids_m.group(1)):
+                    self._walk_pages(int(ref_m.group(1)), page_ids, visited)
+
+    # ------------------------------------------------------------------
+    # Content stream resolution
+    # ------------------------------------------------------------------
+
+    def _content_stream_for_page(self, page_body: bytes) -> Optional[bytes]:
+        """Resolve the /Contents entry of a page object to raw stream bytes."""
+        # Single indirect reference: /Contents 5 0 R
+        single_m = re.search(rb"/Contents\s+(\d+)\s+\d+\s+R", page_body)
+        if single_m:
+            return self.get_stream(int(single_m.group(1)))
+
+        # Array of references: /Contents [5 0 R 6 0 R ...]
+        array_m = re.search(rb"/Contents\s*\[([^\]]+)\]", page_body)
+        if array_m:
+            parts = []
+            for ref_m in re.finditer(rb"(\d+)\s+\d+\s+R", array_m.group(1)):
+                s = self.get_stream(int(ref_m.group(1)))
+                if s:
+                    parts.append(s)
+            if parts:
+                return b" ".join(parts)
+
+        # Inline stream (unusual but valid for simple pages)
+        return self._extract_stream_bytes(page_body)

--- a/src/pdfextract/schema.py
+++ b/src/pdfextract/schema.py
@@ -1,0 +1,76 @@
+"""Data models for PDF extraction results."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class PageResult:
+    """Text content and statistics for a single extracted page."""
+
+    page_number: int
+    text: str
+    word_count: int = field(init=False)
+    char_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.word_count = len(self.text.split())
+        self.char_count = len(self.text)
+
+
+@dataclass
+class ExtractionResult:
+    """Aggregated result of a PDF extraction run."""
+
+    source: str
+    page_count: int
+    pages: List[PageResult] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def full_text(self) -> str:
+        return "\n\n".join(p.text for p in self.pages if p.text.strip())
+
+    @property
+    def word_count(self) -> int:
+        return sum(p.word_count for p in self.pages)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source": self.source,
+            "page_count": self.page_count,
+            "word_count": self.word_count,
+            "metadata": self.metadata,
+            "errors": self.errors,
+            "pages": [
+                {
+                    "page": p.page_number,
+                    "text": p.text,
+                    "words": p.word_count,
+                    "chars": p.char_count,
+                }
+                for p in self.pages
+            ],
+        }
+
+    def to_markdown(self) -> str:
+        lines: List[str] = [
+            f"# Extracted Text: {self.source}",
+            "",
+            f"**Pages**: {self.page_count} | **Words**: {self.word_count}",
+            "",
+        ]
+        if self.metadata:
+            lines += ["## Metadata", ""]
+            for k, v in self.metadata.items():
+                lines.append(f"- **{k}**: {v}")
+            lines.append("")
+        for page in self.pages:
+            lines += [f"## Page {page.page_number}", "", page.text or "*(no text)*", ""]
+        return "\n".join(lines)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)

--- a/tests/test_pdfextract.py
+++ b/tests/test_pdfextract.py
@@ -1,18 +1,300 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""Tests for pdfextract.
 
-def test_import():
-    import pdfextract
-    assert hasattr(pdfextract, 'extract_pdf')
+Covers the data models, string decoders, text extraction from content streams,
+and end-to-end extraction from a programmatically generated minimal PDF.
+"""
+from __future__ import annotations
 
-def test_pdf_parse_error():
-    import pdfextract
-    assert hasattr(pdfextract, 'PDFParseError')
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
 
-def test_page_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'PageResult')
+import pytest
 
-def test_extraction_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'ExtractionResult')
+# Ensure the src layout is on the path when running without install
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import pdfextract
+from pdfextract import (
+    ExtractionResult,
+    PDFExtractor,
+    PDFParseError,
+    PageResult,
+    extract_pdf,
+)
+from pdfextract.extractor import _extract_text_from_stream
+from pdfextract.parser import _decode_hex_string, _decode_literal_string
+
+
+# ---------------------------------------------------------------------------
+# Minimal PDF factory
+# ---------------------------------------------------------------------------
+
+def _make_pdf(*page_texts: str) -> bytes:
+    """Build a minimal, standards-compliant PDF with one page per *page_texts* entry."""
+    objs: dict[int, bytes] = {}
+    n_pages = len(page_texts)
+
+    # Object 1: Catalog
+    objs[1] = b"<< /Type /Catalog /Pages 2 0 R >>"
+
+    # Object 2: Pages node
+    kids = " ".join(f"{3 + i} 0 R" for i in range(n_pages))
+    objs[2] = (
+        f"<< /Type /Pages /Kids [{kids}] /Count {n_pages} >>".encode()
+    )
+
+    # Page objects and content streams (two objects per page)
+    for i, text in enumerate(page_texts):
+        page_obj_id = 3 + i
+        stream_obj_id = 3 + n_pages + i
+        objs[page_obj_id] = (
+            f"<< /Type /Page /Parent 2 0 R "
+            f"/MediaBox [0 0 612 792] "
+            f"/Contents {stream_obj_id} 0 R >>".encode()
+        )
+        stream_body = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET\n".encode()
+        objs[stream_obj_id] = (
+            b"<< /Length " + str(len(stream_body)).encode() + b" >>\n"
+            b"stream\n" + stream_body + b"endstream"
+        )
+
+    # --- Serialize ---
+    lines: list[bytes] = [b"%PDF-1.4\n"]
+    offsets: dict[int, int] = {}
+
+    for obj_id in sorted(objs):
+        offsets[obj_id] = sum(len(l) for l in lines)
+        lines.append(f"{obj_id} 0 obj\n".encode())
+        lines.append(objs[obj_id])
+        lines.append(b"\nendobj\n")
+
+    xref_offset = sum(len(l) for l in lines)
+    total_objs = max(objs) + 1
+
+    lines.append(b"xref\n")
+    lines.append(f"0 {total_objs}\n".encode())
+    lines.append(b"0000000000 65535 f \r\n")
+    for obj_id in range(1, total_objs):
+        off = offsets.get(obj_id, 0)
+        lines.append(f"{off:010d} 00000 n \r\n".encode())
+
+    lines.append(b"trailer\n")
+    lines.append(f"<< /Size {total_objs} /Root 1 0 R >>\n".encode())
+    lines.append(b"startxref\n")
+    lines.append(f"{xref_offset}\n".encode())
+    lines.append(b"%%EOF\n")
+
+    return b"".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+class TestPublicAPI:
+    def test_extract_pdf_importable(self):
+        assert callable(extract_pdf)
+
+    def test_pdf_parse_error_is_exception(self):
+        assert issubclass(PDFParseError, Exception)
+
+    def test_page_result_in_namespace(self):
+        assert PageResult is pdfextract.PageResult
+
+    def test_extraction_result_in_namespace(self):
+        assert ExtractionResult is pdfextract.ExtractionResult
+
+    def test_version_string(self):
+        assert isinstance(pdfextract.__version__, str)
+        assert pdfextract.__version__
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+class TestPageResult:
+    def test_word_and_char_counts(self):
+        p = PageResult(page_number=1, text="Hello World")
+        assert p.word_count == 2
+        assert p.char_count == 11
+
+    def test_empty_text(self):
+        p = PageResult(page_number=1, text="")
+        assert p.word_count == 0
+        assert p.char_count == 0
+
+
+class TestExtractionResult:
+    def _make_result(self) -> ExtractionResult:
+        pages = [
+            PageResult(page_number=1, text="Hello World"),
+            PageResult(page_number=2, text="Foo Bar Baz"),
+        ]
+        return ExtractionResult(
+            source="test.pdf",
+            page_count=2,
+            pages=pages,
+            metadata={"Title": "Test"},
+        )
+
+    def test_full_text_joins_pages(self):
+        r = self._make_result()
+        assert "Hello World" in r.full_text
+        assert "Foo Bar Baz" in r.full_text
+
+    def test_word_count_sums_pages(self):
+        r = self._make_result()
+        assert r.word_count == 5
+
+    def test_to_dict_structure(self):
+        r = self._make_result()
+        d = r.to_dict()
+        assert d["source"] == "test.pdf"
+        assert d["page_count"] == 2
+        assert len(d["pages"]) == 2
+        assert d["pages"][0]["text"] == "Hello World"
+
+    def test_to_json_valid(self):
+        r = self._make_result()
+        parsed = json.loads(r.to_json())
+        assert parsed["word_count"] == 5
+
+    def test_to_markdown_contains_headers(self):
+        r = self._make_result()
+        md = r.to_markdown()
+        assert "## Page 1" in md
+        assert "## Metadata" in md
+        assert "**Title**: Test" in md
+
+
+# ---------------------------------------------------------------------------
+# String decoders
+# ---------------------------------------------------------------------------
+
+class TestStringDecoders:
+    def test_literal_plain(self):
+        assert _decode_literal_string(b"Hello") == "Hello"
+
+    def test_literal_escaped_parens(self):
+        assert _decode_literal_string(b"a\\(b\\)c") == "a(b)c"
+
+    def test_literal_newline_escape(self):
+        assert _decode_literal_string(b"a\\nb") == "a\nb"
+
+    def test_literal_octal(self):
+        # octal 110 = 'H', 145 = 'e', 154 = 'l', 157 = 'o'
+        assert _decode_literal_string(b"\\110\\145\\154\\154\\157") == "Hello"
+
+    def test_hex_string_basic(self):
+        assert _decode_hex_string(b"48656c6c6f") == "Hello"
+
+    def test_hex_string_with_spaces(self):
+        assert _decode_hex_string(b"48 65 6c 6c 6f") == "Hello"
+
+    def test_hex_string_odd_length_padded(self):
+        # Odd hex digits: spec says pad with 0 on the right
+        result = _decode_hex_string(b"4")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Content-stream text extraction
+# ---------------------------------------------------------------------------
+
+class TestStreamExtraction:
+    def test_simple_tj(self):
+        stream = b"BT (Hello World) Tj ET"
+        assert "Hello" in _extract_text_from_stream(stream)
+
+    def test_tj_array(self):
+        stream = b"BT [(Foo) 20 (Bar)] TJ ET"
+        result = _extract_text_from_stream(stream)
+        assert "Foo" in result
+        assert "Bar" in result
+
+    def test_multiple_bt_blocks(self):
+        stream = b"BT (First) Tj ET BT (Second) Tj ET"
+        result = _extract_text_from_stream(stream)
+        assert "First" in result
+        assert "Second" in result
+
+    def test_no_bt_blocks_returns_empty(self):
+        stream = b"/F1 12 Tf"
+        assert _extract_text_from_stream(stream) == ""
+
+    def test_escaped_string(self):
+        stream = rb"BT (Hello\nWorld) Tj ET"
+        result = _extract_text_from_stream(stream)
+        assert "Hello" in result
+
+
+# ---------------------------------------------------------------------------
+# End-to-end extraction from in-memory PDFs
+# ---------------------------------------------------------------------------
+
+class TestExtraction:
+    def _write_pdf(self, pdf_bytes: bytes) -> Path:
+        tmp = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
+        tmp.write(pdf_bytes)
+        tmp.close()
+        return Path(tmp.name)
+
+    def test_single_page_text(self):
+        path = self._write_pdf(_make_pdf("Hello World"))
+        result = PDFExtractor(str(path)).extract()
+        assert result.page_count == 1
+        assert "Hello" in result.full_text
+
+    def test_multi_page(self):
+        path = self._write_pdf(_make_pdf("Page one", "Page two", "Page three"))
+        result = PDFExtractor(str(path)).extract()
+        assert result.page_count == 3
+        assert "Page one" in result.full_text
+        assert "Page three" in result.full_text
+
+    def test_max_pages_limit(self):
+        path = self._write_pdf(_make_pdf("A", "B", "C"))
+        result = PDFExtractor(str(path), max_pages=2).extract()
+        assert result.page_count == 2
+
+    def test_extract_pdf_text_format(self):
+        path = self._write_pdf(_make_pdf("Hello extraction"))
+        out = extract_pdf(str(path), output_format="text")
+        assert "Hello" in out
+
+    def test_extract_pdf_json_format(self):
+        path = self._write_pdf(_make_pdf("JSON test"))
+        out = extract_pdf(str(path), output_format="json")
+        parsed = json.loads(out)
+        assert parsed["page_count"] == 1
+
+    def test_extract_pdf_markdown_format(self):
+        path = self._write_pdf(_make_pdf("Markdown test"))
+        out = extract_pdf(str(path), output_format="markdown")
+        assert "## Page 1" in out
+
+    def test_output_written_to_file(self):
+        path = self._write_pdf(_make_pdf("Save test"))
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as out_f:
+            out_path = out_f.name
+        extract_pdf(str(path), output_path=out_path)
+        content = Path(out_path).read_text(encoding="utf-8")
+        assert "Save" in content
+
+    def test_invalid_file_returns_error(self):
+        path = self._write_pdf(b"not a pdf at all")
+        result = PDFExtractor(str(path)).extract()
+        assert result.errors
+
+    def test_nonexistent_file_returns_error(self):
+        result = PDFExtractor("/nonexistent/path/file.pdf").extract()
+        assert result.errors
+
+    def test_word_count_accurate(self):
+        path = self._write_pdf(_make_pdf("one two three"))
+        result = PDFExtractor(str(path)).extract()
+        assert result.word_count == 3


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Package restructure**: Monolithic `pdfextract.py` split into a proper `src/pdfextract/` package (`parser.py`, `extractor.py`, `schema.py`, `gui.py`, `__main__.py`) for JOSS-quality code organisation and correct installability.
- **Bug fixes**: `src/pdfextract/__init__.py` previously caused `ImportError` on import (referenced non-existent submodules). PDF parser now correctly walks the `/Pages` object tree, handles PDF 1.5+ xref streams, decodes hex strings, concatenates multi-stream `/Contents` arrays, and anchors `startxref` search to `%%EOF`.
- **GUI added**: `pdfextract --gui` / `pdfextract-gui` launches a Tk desktop application — file picker, format/max-pages options, background-threaded extraction with progress bar, scrollable output, and save-as dialog. Zero additional dependencies (uses the Python standard library `tkinter`).
- **Tests expanded**: 4 attribute-existence stubs replaced with 34 functional tests covering data models, string decoders, stream parsing, and end-to-end extraction from programmatically constructed minimal PDFs.
- **Docs corrected**: `paper.md` rewritten to accurately describe the pure-Python implementation (removed false claims about `pdfminer.six`, `camelot`, and pandas DataFrame output). `CHANGELOG.md` and `CITATION.cff` updated to v0.2.0.

## Test plan

- [ ] `pip install -e . && pytest tests/ -v` — all 34 tests pass
- [ ] `pdfextract <file.pdf>` — text output to stdout
- [ ] `pdfextract <file.pdf> -f json -o out.json` — JSON file written
- [ ] `pdfextract --gui` — GUI window opens, extraction runs, output displayed
- [ ] `python -m pdfextract --help` — help text printed

https://claude.ai/code/session_0186cLFDi1nZ1q8XxuCTxzBY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186cLFDi1nZ1q8XxuCTxzBY)_