### PR TITLE
feat: JOSS-level refactor — proper package structure, bug fixes, GUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-      - run: pip install -e . pytest
-      - run: pytest tests/ -v
+          python-version: '3.12'
+      - name: Install system tkinter
+        run: sudo apt-get install -y python3-tk
+      - name: Install package and test dependencies
+        run: pip install -e . pytest
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Pytest cache
+.pytest_cache/
+
+# mypy / type checkers
+.mypy_cache/
+.dmypy.json
+
+# Coverage
+.coverage
+htmlcov/
+
+# IDE
+.idea/
+.vscode/
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,62 @@
 # Changelog
 
 All notable changes to pdfextract are documented here.
+Versions follow [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2024-01-15
+## [0.2.0] - 2026-04-30
 
 ### Added
-- Initial release of PDFExtract
-- Text extraction with reading-order reconstruction for single and multi-column layouts
-- Rule-based table detection with CSV and pandas DataFrame export
-- Figure bounding-box detection and captioned image cropping
-- Heuristic section header and metadata (title, authors, abstract) parsing
-- Batch processing CLI with glob pattern input support
-- Output formats: plain text, JSON (structured), and Markdown
-- Optional pdfplumber and pymupdf backends selectable at runtime
-- Unit tests covering extraction accuracy on sample academic PDFs
-- README with installation, CLI usage, and Python API reference
+- `src/` package layout with dedicated sub-modules:
+  `schema.py`, `extractor.py`, `cli.py`, `gui.py`
+- Tkinter-based graphical interface (`pdfextract-gui` command)
+  with threaded extraction, format selector, page-limit spinner,
+  progress bar, and save-output dialog
+- Cross-reference stream (PDF 1.5+) parser (`_parse_xref_stream`)
+- `/Prev` chain traversal for incremental-update PDFs
+- Document-order page extraction via proper `/Pages` tree traversal
+  (`_collect_page_ids`, `_find_pages_root`); no longer relies on
+  heuristic object-ID ordering
+- Metadata extraction from the `/Info` dictionary
+  (Title, Author, Subject, Keywords, Creator, Producer, CreationDate)
+- `ExtractionResult.to_json()` method
+- `ExtractionResult.to_markdown()` now includes a **Warnings** section
+  when non-fatal errors occurred
+- `chars` field in the JSON `pages` array
+- TJ kerning-gap heuristic: negative offsets < −100 text-space units
+  are mapped to a word space
+- Support for multiple `/Contents` streams per page (array form)
+- `PDFExtractor` now raises `PDFParseError` for missing files
+- 61-test test suite covering data model, low-level utilities,
+  error handling, and an end-to-end smoke test with a
+  synthetically constructed minimal PDF
+- `pyproject.toml` now includes `[tool.pytest.ini_options]`
+  with `pythonpath = ["src"]` for zero-config test discovery
+
+### Fixed
+- `_parse_xref_table`: raised the read window from 4 096 B to 1 MiB,
+  preventing truncation of large xref tables
+- `_find_startxref`: now searches the last 2 048 bytes (was 1 024)
+- `_decode_pdf_string`: octal escape now strictly matches 1–3 octal
+  digits to avoid `int(..., 8)` failures on non-octal characters
+- `_extract_text_from_stream`: BT/ET regex uses word boundaries
+  (`\bBT\b … \bET\b`) to prevent false matches on operator names
+- Page order is now the PDF document order, not xref object-ID order
+
+### Changed
+- Script entry point changed from `pdfextract:_cli` (root module)
+  to `pdfextract.cli:main` (package sub-module)
+- `pyproject.toml` switched from `py-modules` to `packages.find`
+  with `where = ["src"]`
+- Version bumped from 0.1.0 to 0.2.0
+
+## [0.1.0] - 2026-04-23
+
+### Added
+- Initial release: pure-Python PDF text extractor
+- Classic xref table parsing
+- FlateDecode (zlib) stream decompression
+- `Tj` / `TJ` operator handling; literal and hex string decoding
+- `PageResult` and `ExtractionResult` data model
+- `extract_pdf()` convenience function
+- CLI (`pdfextract`)
+- Output formats: plain text, Markdown, JSON

--- a/README.md
+++ b/README.md
@@ -1,1 +1,142 @@
 # pdfextract
+
+**pdfextract** is a pure-Python library and command-line tool for extracting structured text and metadata from PDF files — no external binaries required.
+
+[![CI](https://github.com/vdeshmukh203/pdfextract/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/pdfextract/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/)
+
+---
+
+## Features
+
+- **Pure Python** — no poppler, ghostscript, or Java dependencies
+- **Page-tree traversal** — correct document-order extraction via the PDF `/Pages` hierarchy
+- **Cross-reference streams** — supports both classic xref tables (PDF 1.0–1.4) and xref streams (PDF 1.5+)
+- **Multiple content-stream operators** — `Tj`, `TJ`, `'`, `"` with literal and hex string decoding
+- **TJ kerning-gap heuristic** — large negative spacing values are mapped to word spaces
+- **Metadata extraction** — Title, Author, Subject, Keywords, Creator, Producer, CreationDate
+- **Three output formats** — plain text, Markdown, JSON
+- **GUI** — tkinter-based graphical interface (`pdfextract-gui`)
+- **Graceful degradation** — non-fatal errors are collected and reported; partially damaged PDFs produce partial output
+
+## Installation
+
+```bash
+pip install pdfextract
+```
+
+For the graphical interface on Linux, ensure tkinter is available:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install python3-tk
+
+# Fedora / RHEL
+sudo dnf install python3-tkinter
+```
+
+## Quick start
+
+### Python API
+
+```python
+from pdfextract import extract_pdf, PDFExtractor
+
+# One-line convenience function
+text = extract_pdf("paper.pdf")
+md   = extract_pdf("paper.pdf", output_format="markdown")
+data = extract_pdf("paper.pdf", output_format="json")
+
+# Lower-level control
+result = PDFExtractor("paper.pdf", max_pages=10).extract()
+print(f"Pages: {result.page_count}, Words: {result.word_count}")
+print(result.metadata)   # {'Title': '...', 'Author': '...', ...}
+for page in result.pages:
+    print(f"Page {page.page_number}: {page.word_count} words")
+```
+
+### Command line
+
+```
+usage: pdfextract [-h] [-o FILE] [-f {text,markdown,json}] [-p N] [--version] input
+
+positional arguments:
+  input                 Path to the input PDF file.
+
+options:
+  -o, --output FILE     Write output to FILE instead of stdout.
+  -f, --format          Output format: text (default), markdown, or json.
+  -p, --max-pages N     Extract at most N pages (0 = all, the default).
+```
+
+Examples:
+
+```bash
+pdfextract paper.pdf
+pdfextract paper.pdf -f markdown -o paper.md
+pdfextract paper.pdf -f json -p 5
+```
+
+### Graphical interface
+
+```bash
+pdfextract-gui
+```
+
+The GUI allows you to browse for a PDF, choose an output format, set a page limit, extract, and save the result — all without touching the command line.
+
+## Output formats
+
+| Format     | Description                                              |
+|------------|----------------------------------------------------------|
+| `text`     | Plain text, one page per paragraph.                      |
+| `markdown` | Metadata section + `## Page N` headings.                 |
+| `json`     | Structured JSON with `source`, `metadata`, `pages`, `errors`. |
+
+### JSON schema
+
+```json
+{
+  "source":     "paper.pdf",
+  "page_count": 12,
+  "word_count": 4821,
+  "metadata":   {"Title": "...", "Author": "..."},
+  "errors":     [],
+  "pages": [
+    {"page": 1, "text": "...", "words": 412, "chars": 2341},
+    ...
+  ]
+}
+```
+
+## Known limitations
+
+- **Encrypted PDFs** are not supported; extraction returns an xref error.
+- **Object streams** (PDF 1.5 ObjStm) are not decoded; pages stored in object streams will be missing from the output.
+- **Font encoding remapping** is not implemented; text is decoded as ISO-8859-1 (Latin-1). CID-keyed fonts and non-Latin scripts may produce garbled output.
+- **Reading-order reconstruction** is not performed; words are extracted in the order they appear in the content stream, which may differ from visual reading order in multi-column layouts.
+
+## Running tests
+
+```bash
+pip install -e ".[dev]"
+pytest tests/ -v
+```
+
+## Citation
+
+If you use pdfextract in research, please cite:
+
+```bibtex
+@article{deshmukh2026pdfextract,
+  title   = {pdfextract: Structured extraction of text and metadata from PDF files},
+  author  = {Deshmukh, Vaibhav},
+  journal = {Journal of Open Source Software},
+  year    = {2026}
+}
+```
+
+## License
+
+MIT © Vaibhav Deshmukh

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'pdfextract: Structured extraction of text, tables, and figures from scientific PDF documents'
+title: 'pdfextract: Pure-Python structured extraction of text and metadata from PDF documents'
 tags:
   - Python
   - PDF
@@ -14,20 +14,80 @@ authors:
 affiliations:
   - name: Independent Researcher, Nagpur, India
     index: 1
-date: 23 April 2026
+date: 30 April 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-`pdfextract` is a Python library and command-line tool for structured extraction of content from scientific PDF documents. It combines PDF parsing (via `pdfminer.six`), table detection (via heuristic whitespace analysis and `camelot`), and figure boundary detection (via bounding-box analysis of non-text PDF objects) to produce structured output in JSON or Markdown format. Extracted content includes section-segmented body text, tables as pandas DataFrames, figure captions, and metadata (title, authors, abstract, DOI). `pdfextract` is designed for batch processing of paper corpora in systematic review and meta-analysis pipelines.
+`pdfextract` is a pure-Python library and command-line tool for extracting
+structured text and metadata from PDF documents without requiring any external
+binary dependencies (no Poppler, Ghostscript, or Java).  It implements a
+self-contained PDF parser that reads both classic cross-reference tables
+(PDF 1.0–1.4) and cross-reference streams (PDF 1.5+), traverses the document
+page tree to guarantee correct reading order, decodes FlateDecode (zlib)
+content streams, and interprets PDF text-show operators (`Tj`, `TJ`, `'`, `"`)
+to recover human-readable text.  Extracted content includes per-page text with
+word and character counts, document metadata from the `/Info` dictionary
+(title, authors, subject, keywords, creation date), and non-fatal error reports
+for partially damaged files.  Output is available as plain text, Markdown, or
+structured JSON.  An optional tkinter-based graphical interface
+(`pdfextract-gui`) provides a point-and-click workflow for users who prefer not
+to use the command line.
 
 # Statement of Need
 
-Scientific text mining pipelines require reliable extraction of structured content from PDF documents, but existing tools either require commercial licences, lack section-awareness, or produce poorly structured output that requires extensive post-processing [@gao2023reproducibility]. `pdfextract` targets the research workflow of processing hundreds to thousands of papers: it provides a batch mode, consistent JSON output schema, and graceful degradation when content cannot be reliably extracted rather than silently producing malformed output. The structured output integrates directly with downstream NLP tools, enabling reproducible corpus construction for meta-analyses and systematic literature reviews [@stodden2016enhancing; @pineau2021improving].
+Scientific text-mining pipelines require reliable, dependency-light extraction
+of content from PDF documents, but existing open-source tools introduce
+substantial installation overhead: `pdfminer.six` [@pdfminer] requires a
+compiled C extension, `pymupdf` [@pymupdf] ships large binary wheels, and
+`camelot` [@camelot] depends on Ghostscript and OpenCV.  This friction
+discourages reproducible environment specifications and complicates deployment
+in restricted computing environments (HPC clusters, Docker images, GitHub
+Actions runners).
+
+`pdfextract` fills this gap by providing a stdlib-only parser — the only
+runtime dependency beyond the Python standard library is `zlib`, which is
+bundled with CPython.  This makes it trivially installable via `pip` on any
+platform and suitable for use in automated batch pipelines that process
+hundreds to thousands of papers for systematic reviews and meta-analyses
+[@stodden2016enhancing; @pineau2021improving].  The consistent JSON output
+schema integrates directly with downstream NLP tools, and graceful degradation
+on malformed or encrypted PDFs means batch jobs continue rather than crashing
+on a single problematic file [@gao2023reproducibility].
+
+# Implementation
+
+`pdfextract` implements the following PDF specification components:
+
+**Cross-reference parsing.**  Both classic `xref` tables and cross-reference
+streams (PDF 1.5+) are supported.  `/Prev` chains in incremental-update PDFs
+are followed to completion, with newer entries taking precedence over older
+ones as required by the specification.
+
+**Page tree traversal.**  Rather than scanning all objects for `/Type /Page`
+heuristically, the extractor reads the document catalogue (`/Root`), resolves
+the `/Pages` root node, and recursively follows `/Kids` arrays to collect page
+object IDs in document order.  A linear scan fallback is provided for PDFs
+with malformed page trees.
+
+**Content stream decoding.**  FlateDecode (zlib) compressed streams are
+decompressed with a raw-deflate fallback.  Pages whose `/Contents` value is an
+array of indirect references have all streams concatenated before parsing.
+
+**Text extraction.**  A compiled regular-expression tokeniser processes each
+`BT … ET` text block, handling `Tj` (show string), `TJ` (show string array
+with kerning), `'` and `"` (move-and-show) operators.  Both PDF literal
+strings (`(…)`) and hex strings (`<…>`) are decoded.  In TJ arrays, kerning
+adjustments more negative than −100 text-space units are heuristically
+converted to word spaces.
+
+**Metadata.**  The `/Info` dictionary is located via the trailer `/Info`
+reference and decoded into a Python dictionary.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for portions of the implementation and this
+manuscript.  All design decisions are the author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfextract"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pure-Python structured text and metadata extractor for PDF files"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -16,12 +16,22 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Text Processing",
     "Topic :: Scientific/Engineering",
 ]
 
 [project.scripts]
-pdfextract = "pdfextract:_cli"
+pdfextract     = "pdfextract.cli:main"
+pdfextract-gui = "pdfextract.gui:main"
 
-[tool.setuptools]
-py-modules = ["pdfextract"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths  = ["tests"]

--- a/src/pdfextract/__init__.py
+++ b/src/pdfextract/__init__.py
@@ -1,17 +1,104 @@
 """
-pdfextract: Structured scientific PDF content extraction tool.
+pdfextract: Structured text and metadata extraction from PDF files.
 
-Parses scientific PDF documents and extracts structured content: sections,
-abstracts, figures, tables, captions, equations, citations, and metadata.
-Output is emitted as structured JSON, enabling downstream text mining,
-dataset construction, and reproducible scientific content analysis pipelines.
+Pure-Python PDF parser (no external binaries) that reads cross-reference
+tables and streams, traverses the document page tree, decodes content
+streams, and outputs plain text, Markdown, or JSON.
+
+Quick start::
+
+    from pdfextract import extract_pdf
+
+    text = extract_pdf("paper.pdf")
+    md   = extract_pdf("paper.pdf", output_format="markdown")
+    data = extract_pdf("paper.pdf", output_format="json")
+
+For lower-level control::
+
+    from pdfextract import PDFExtractor
+
+    result = PDFExtractor("paper.pdf", max_pages=10).extract()
+    print(result.metadata)
+    for page in result.pages:
+        print(f"Page {page.page_number}: {page.word_count} words")
 """
+from __future__ import annotations
 
-__version__ = "0.1.0"
+from pathlib import Path
+from typing import Optional
+
+from .extractor import PDFExtractor, PDFParseError
+from .schema import ExtractionResult, PageResult
+
+__version__ = "0.2.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .extractor import PDFExtractor
-from .schema import ExtractionResult
+__all__ = [
+    "PDFExtractor",
+    "PDFParseError",
+    "ExtractionResult",
+    "PageResult",
+    "extract_pdf",
+    "__version__",
+]
 
-__all__ = ["PDFExtractor", "ExtractionResult"]
+
+def extract_pdf(
+    path: str,
+    output_format: str = "text",
+    output_path: Optional[str] = None,
+    max_pages: int = 0,
+) -> str:
+    """Extract text from a PDF file.
+
+    Parameters
+    ----------
+    path:
+        Input PDF file path.
+    output_format:
+        One of ``"text"`` (default), ``"markdown"``, or ``"json"``.
+    output_path:
+        If given, write the result to this file path (UTF-8 encoding).
+    max_pages:
+        Maximum number of pages to process.  ``0`` processes all pages.
+
+    Returns
+    -------
+    str
+        Extracted content formatted according to *output_format*.
+
+    Raises
+    ------
+    PDFParseError
+        If *path* is not a valid PDF file.
+    OSError
+        If *path* cannot be read or *output_path* cannot be written.
+
+    Examples
+    --------
+    >>> text = extract_pdf("paper.pdf")
+    >>> md   = extract_pdf("paper.pdf", output_format="markdown")
+    >>> _    = extract_pdf("paper.pdf", output_format="json", output_path="out.json")
+    """
+    result = PDFExtractor(path, max_pages=max_pages).extract()
+
+    if output_format == "json":
+        out = result.to_json()
+    elif output_format == "markdown":
+        out = result.to_markdown()
+    else:
+        out = result.full_text
+
+    if output_path:
+        Path(output_path).write_text(out, encoding="utf-8")
+
+    return out
+
+
+# Keep the private _cli name for backwards compatibility with the old
+# pyproject.toml entry point (pdfextract = "pdfextract:_cli").
+def _cli() -> None:  # pragma: no cover
+    from .cli import main
+    import sys
+    sys.exit(main())

--- a/src/pdfextract/cli.py
+++ b/src/pdfextract/cli.py
@@ -1,0 +1,88 @@
+"""Command-line interface for pdfextract."""
+from __future__ import annotations
+
+import sys
+from typing import List, Optional
+
+from . import __version__, extract_pdf
+from .extractor import PDFParseError
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point for the ``pdfextract`` command.
+
+    Parameters
+    ----------
+    argv:
+        Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns
+    -------
+    int
+        Exit code (0 on success, 1 on error).
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="pdfextract",
+        description="Extract structured text and metadata from PDF files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  pdfextract paper.pdf\n"
+            "  pdfextract paper.pdf -f markdown -o paper.md\n"
+            "  pdfextract paper.pdf -f json -p 5\n"
+        ),
+    )
+    parser.add_argument("input", help="Path to the input PDF file.")
+    parser.add_argument(
+        "-o", "--output",
+        default=None,
+        metavar="FILE",
+        help="Write output to FILE instead of stdout.",
+    )
+    parser.add_argument(
+        "-f", "--format",
+        choices=["text", "markdown", "json"],
+        default="text",
+        dest="fmt",
+        help="Output format: text (default), markdown, or json.",
+    )
+    parser.add_argument(
+        "-p", "--max-pages",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Extract at most N pages (0 = all, the default).",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        out = extract_pdf(
+            args.input,
+            output_format=args.fmt,
+            output_path=args.output,
+            max_pages=args.max_pages,
+        )
+    except PDFParseError as exc:
+        print(f"pdfextract: error: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"pdfextract: error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        print(f"Written to {args.output}")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pdfextract/extractor.py
+++ b/src/pdfextract/extractor.py
@@ -1,0 +1,624 @@
+"""
+Pure-Python PDF parser and text extractor.
+
+Supports:
+- Classic cross-reference tables (PDF 1.0–1.4)
+- Cross-reference streams (PDF 1.5+)
+- /Prev chain traversal for incremental updates
+- Document-order page traversal via the /Pages tree
+- Tj, TJ, ' and " text-show operators
+- Literal and hex-encoded PDF strings
+- FlateDecode (zlib) compressed content streams
+- Metadata extraction from the /Info dictionary
+
+Limitations:
+- No font/encoding remapping; text decoded as Latin-1
+- No support for encrypted (password-protected) PDFs
+- Object streams (PDF 1.5 ObjStm) not decoded
+"""
+from __future__ import annotations
+
+import re
+import zlib
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+from .schema import ExtractionResult, PageResult
+
+
+# ---------------------------------------------------------------------------
+# Public exception
+# ---------------------------------------------------------------------------
+
+class PDFParseError(Exception):
+    """Raised when fundamental PDF structure cannot be read."""
+
+
+# ---------------------------------------------------------------------------
+# Low-level binary helpers
+# ---------------------------------------------------------------------------
+
+def _read_be_int(data: bytes, start: int, width: int) -> int:
+    """Read a big-endian unsigned integer of *width* bytes."""
+    if width == 0:
+        return 1  # default type field value in xref streams
+    value = 0
+    for byte in data[start : start + width]:
+        value = (value << 8) | byte
+    return value
+
+
+def _decompress(raw: bytes) -> bytes:
+    """Attempt zlib decompression; return *raw* unchanged on failure."""
+    for wbits in (15, -15):
+        try:
+            return zlib.decompress(raw, wbits)
+        except zlib.error:
+            pass
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Indirect object parsing
+# ---------------------------------------------------------------------------
+
+def _parse_obj_at(data: bytes, offset: int) -> Tuple[int, bytes]:
+    """Return *(obj_id, body_bytes)* for the indirect object at *offset*.
+
+    Reads up to 64 KiB from *offset*; raises :class:`PDFParseError` if the
+    ``N G obj`` marker is absent.
+    """
+    chunk = data[offset : offset + 65536]
+    m = re.search(rb"(\d+)\s+\d+\s+obj\b", chunk)
+    if not m:
+        raise PDFParseError(f"obj marker not found at offset {offset}")
+    start = m.end()
+    end_m = re.search(rb"\bendobj\b", chunk[start:])
+    body = chunk[start : start + end_m.start()] if end_m else chunk[start:]
+    return int(m.group(1)), body
+
+
+def _extract_stream_bytes(obj_body: bytes) -> Optional[bytes]:
+    """Extract and decompress the stream payload from an object body.
+
+    Returns *None* if the object has no stream.
+    """
+    m = re.search(rb"stream\r?\n", obj_body)
+    if not m:
+        return None
+    start = m.end()
+    end_m = re.search(rb"\bendstream\b", obj_body[start:])
+    raw = obj_body[start : start + (end_m.start() if end_m else len(obj_body))]
+    header = obj_body[:start]
+    if b"FlateDecode" in header:
+        raw = _decompress(raw)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference parsing
+# ---------------------------------------------------------------------------
+
+def _find_startxref(data: bytes) -> int:
+    """Return the byte offset stored in the ``startxref`` trailer token."""
+    tail = data[-2048:]
+    m = re.search(rb"startxref\s+(\d+)\s*(?:%%EOF)?", tail)
+    if not m:
+        raise PDFParseError("startxref not found in file tail")
+    return int(m.group(1))
+
+
+def _parse_xref_table(
+    data: bytes, offset: int
+) -> Tuple[Dict[int, int], Optional[int]]:
+    """Parse a classic ``xref`` table.
+
+    Returns a mapping ``{obj_id: byte_offset}`` and the ``/Prev`` offset (or
+    *None* if absent).
+    """
+    offsets: Dict[int, int] = {}
+    # Read up to 1 MiB — large xref tables can be hundreds of KB
+    end = min(offset + 1_048_576, len(data))
+    chunk = data[offset:end].decode("latin-1", errors="replace")
+    lines = chunk.splitlines()
+
+    i = 0
+    if i < len(lines) and lines[i].strip() == "xref":
+        i += 1
+
+    while i < len(lines):
+        line = lines[i].strip()
+        if line == "trailer":
+            i += 1
+            break
+        m = re.match(r"(\d+)\s+(\d+)$", line)
+        if not m:
+            i += 1
+            continue
+        first_obj, count = int(m.group(1)), int(m.group(2))
+        i += 1
+        for j in range(count):
+            if i >= len(lines):
+                break
+            parts = lines[i].strip().split()
+            i += 1
+            if len(parts) >= 3 and parts[2] == "n":
+                offsets[first_obj + j] = int(parts[0])
+
+    # Locate /Prev in the trailer dictionary
+    trailer_text = "\n".join(lines[i : i + 60])
+    pm = re.search(r"/Prev\s+(\d+)", trailer_text)
+    return offsets, (int(pm.group(1)) if pm else None)
+
+
+def _parse_xref_stream(
+    data: bytes, offset: int
+) -> Tuple[Dict[int, int], Optional[int]]:
+    """Parse a cross-reference stream (PDF 1.5+).
+
+    Returns ``{obj_id: byte_offset}`` and the ``/Prev`` offset (or *None*).
+    Falls back to an empty map on any parse error.
+    """
+    offsets: Dict[int, int] = {}
+    try:
+        _, obj_body = _parse_obj_at(data, offset)
+        stream = _extract_stream_bytes(obj_body)
+        if stream is None:
+            return offsets, None
+
+        # /W [type_width  offset_width  gen_width]
+        w_m = re.search(rb"/W\s*\[\s*([\d\s]+?)\s*\]", obj_body)
+        if not w_m:
+            return offsets, None
+        w = [int(x) for x in w_m.group(1).split()]
+        if len(w) < 3 or sum(w) == 0:
+            return offsets, None
+        entry_size = sum(w)
+
+        # /Index defaults to [0 /Size]
+        idx_m = re.search(rb"/Index\s*\[\s*([\d\s]+?)\s*\]", obj_body)
+        if idx_m:
+            idx_vals = [int(x) for x in idx_m.group(1).split()]
+            subsections = [
+                (idx_vals[k], idx_vals[k + 1])
+                for k in range(0, len(idx_vals) - 1, 2)
+            ]
+        else:
+            size_m = re.search(rb"/Size\s+(\d+)", obj_body)
+            size = int(size_m.group(1)) if size_m else 0
+            subsections = [(0, size)]
+
+        pos = 0
+        for first_obj, count in subsections:
+            for j in range(count):
+                if pos + entry_size > len(stream):
+                    break
+                entry = stream[pos : pos + entry_size]
+                pos += entry_size
+                f1 = _read_be_int(entry, 0, w[0])
+                f2 = _read_be_int(entry, w[0], w[1])
+                if f1 == 1:  # in-use, uncompressed object
+                    offsets[first_obj + j] = f2
+
+        prev_m = re.search(rb"/Prev\s+(\d+)", obj_body)
+        return offsets, (int(prev_m.group(1)) if prev_m else None)
+    except Exception:
+        return offsets, None
+
+
+def _load_full_xref(data: bytes) -> Dict[int, int]:
+    """Build the complete xref map, following ``/Prev`` chains.
+
+    Newer entries (from later xref sections) take precedence over older ones,
+    as required by the PDF specification.
+    """
+    offset = _find_startxref(data)
+    visited: Set[int] = set()
+    chains: List[Dict[int, int]] = []
+
+    while offset not in visited:
+        visited.add(offset)
+        # Distinguish classic xref table from xref stream by first non-blank bytes
+        probe = data[offset : offset + 16].lstrip()
+        if probe.startswith(b"xref"):
+            offsets, prev = _parse_xref_table(data, offset)
+        else:
+            offsets, prev = _parse_xref_stream(data, offset)
+        chains.append(offsets)
+        if prev is None:
+            break
+        offset = prev
+
+    # Apply oldest-first so newest entries win
+    combined: Dict[int, int] = {}
+    for chain in reversed(chains):
+        combined.update(chain)
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# Metadata extraction
+# ---------------------------------------------------------------------------
+
+_INFO_KEYS = (
+    "Title",
+    "Author",
+    "Subject",
+    "Keywords",
+    "Creator",
+    "Producer",
+    "CreationDate",
+)
+
+
+def _extract_metadata(data: bytes, xref: Dict[int, int]) -> Dict[str, str]:
+    """Extract document information from the PDF ``/Info`` dictionary."""
+    metadata: Dict[str, str] = {}
+    # Search the tail of the file for the trailer /Info reference
+    tail = data[-65536:].decode("latin-1", errors="replace")
+    info_m = re.search(r"/Info\s+(\d+)\s+\d+\s+R", tail)
+    if not info_m:
+        return metadata
+    info_id = int(info_m.group(1))
+    if info_id not in xref:
+        return metadata
+    try:
+        _, obj_body = _parse_obj_at(data, xref[info_id])
+    except PDFParseError:
+        return metadata
+
+    for key in _INFO_KEYS:
+        pattern = rb"/" + key.encode() + rb"\s*(\([^)]*\)|<[^>]*>)"
+        m = re.search(pattern, obj_body)
+        if not m:
+            continue
+        raw = m.group(1)
+        if raw.startswith(b"("):
+            value = _decode_pdf_string(raw[1:-1])
+        else:
+            value = _decode_hex_string(raw[1:-1])
+        value = value.strip()
+        if value:
+            metadata[key] = value
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# Page tree traversal
+# ---------------------------------------------------------------------------
+
+def _collect_page_ids(
+    data: bytes,
+    xref: Dict[int, int],
+    node_id: int,
+    visited: Optional[Set[int]] = None,
+) -> List[int]:
+    """Recursively collect leaf ``/Page`` object IDs from the page tree.
+
+    Follows the ``/Kids`` arrays in ``/Pages`` (intermediate) nodes and
+    returns the IDs of terminal ``/Page`` nodes in document order.  A
+    *visited* set guards against malformed circular references.
+    """
+    if visited is None:
+        visited = set()
+    if node_id in visited or node_id not in xref:
+        return []
+    visited.add(node_id)
+
+    try:
+        _, obj_body = _parse_obj_at(data, xref[node_id])
+    except PDFParseError:
+        return []
+
+    if re.search(rb"/Type\s*/Pages\b", obj_body):
+        kids_m = re.search(rb"/Kids\s*\[([^\]]+)\]", obj_body)
+        if not kids_m:
+            return []
+        ids: List[int] = []
+        for ref_m in re.finditer(rb"(\d+)\s+\d+\s+R", kids_m.group(1)):
+            ids.extend(_collect_page_ids(data, xref, int(ref_m.group(1)), visited))
+        return ids
+
+    if re.search(rb"/Type\s*/Page\b", obj_body):
+        return [node_id]
+
+    return []
+
+
+def _find_pages_root(data: bytes, xref: Dict[int, int]) -> Optional[int]:
+    """Return the obj_id of the ``/Pages`` root node.
+
+    Reads the document catalogue via the ``/Root`` reference in the trailer.
+    """
+    tail = data[-65536:].decode("latin-1", errors="replace")
+    root_m = re.search(r"/Root\s+(\d+)\s+\d+\s+R", tail)
+    if not root_m:
+        return None
+    root_id = int(root_m.group(1))
+    if root_id not in xref:
+        return None
+    try:
+        _, catalog = _parse_obj_at(data, xref[root_id])
+    except PDFParseError:
+        return None
+    pages_m = re.search(rb"/Pages\s+(\d+)\s+\d+\s+R", catalog)
+    return int(pages_m.group(1)) if pages_m else None
+
+
+# ---------------------------------------------------------------------------
+# PDF string decoders
+# ---------------------------------------------------------------------------
+
+def _decode_pdf_string(s: bytes) -> str:
+    """Decode a PDF literal string, handling ``\\ooo`` octal and escapes."""
+    out: List[str] = []
+    i = 0
+    while i < len(s):
+        b = s[i : i + 1]
+        if b == b"\\":
+            i += 1
+            if i >= len(s):
+                break
+            nc = s[i : i + 1]
+            if nc == b"n":
+                out.append("\n")
+            elif nc == b"r":
+                out.append("\r")
+            elif nc == b"t":
+                out.append("\t")
+            elif nc in (b"(", b")", b"\\"):
+                out.append(nc.decode("latin-1"))
+            elif nc.isdigit():
+                # Octal: 1–3 digits
+                octal_raw = s[i : i + 3].decode("latin-1", errors="replace")
+                om = re.match(r"([0-7]{1,3})", octal_raw)
+                if om:
+                    out.append(chr(int(om.group(1), 8)))
+                    i += len(om.group(1)) - 1
+                else:
+                    out.append(nc.decode("latin-1", errors="replace"))
+            else:
+                out.append(nc.decode("latin-1", errors="replace"))
+        else:
+            out.append(b.decode("latin-1", errors="replace"))
+        i += 1
+    return "".join(out)
+
+
+def _decode_hex_string(s: bytes) -> str:
+    """Decode a PDF hex string (without surrounding angle brackets)."""
+    cleaned = re.sub(rb"\s+", b"", s)
+    if len(cleaned) % 2:
+        cleaned += b"0"
+    try:
+        raw = bytes.fromhex(cleaned.decode("ascii", errors="replace"))
+        return raw.decode("latin-1", errors="replace")
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Text extraction from content streams
+# ---------------------------------------------------------------------------
+
+# Compiled once for performance
+_BT_ET_RE = re.compile(rb"\bBT\b(.+?)\bET\b", re.DOTALL)
+_TJ_ITEM_RE = re.compile(
+    rb"(\((?:[^)(\\]|\\.)*\))"   # literal string
+    rb"|(<[0-9a-fA-F\s]+>)"      # hex string
+    rb"|(-?\d+(?:\.\d*)?)"       # numeric (kerning / spacing)
+)
+_TOKEN_RE = re.compile(
+    rb"(\((?:[^)(\\]|\\.|\((?:[^)(\\]|\\.)*\))*\))"  # (literal string)
+    rb"|(<[0-9a-fA-F\s]+>)"                           # <hex string>
+    rb"|(\[(?:[^\[\]]*)\])"                           # [TJ array]
+    rb"|([A-Za-z'\"*]+)"                              # operator / name
+)
+
+
+def _decode_tj_array(arr_content: bytes) -> str:
+    """Decode a TJ array, inserting a space for large negative kerning gaps."""
+    parts: List[str] = []
+    for m in _TJ_ITEM_RE.finditer(arr_content):
+        lit, hex_s, num = m.group(1), m.group(2), m.group(3)
+        if lit:
+            parts.append(_decode_pdf_string(lit[1:-1]))
+        elif hex_s:
+            parts.append(_decode_hex_string(hex_s[1:-1]))
+        elif num:
+            try:
+                if float(num) < -100:
+                    parts.append(" ")
+            except ValueError:
+                pass
+    return "".join(parts)
+
+
+def _extract_text_from_stream(stream: bytes) -> str:
+    """Extract human-readable text from a PDF content stream.
+
+    Processes every ``BT … ET`` text block, tokenising strings and operators.
+    Handles ``Tj``, ``TJ``, ``'`` and ``"`` (show-string) operators.
+    """
+    parts: List[str] = []
+
+    for bt_block in _BT_ET_RE.finditer(stream):
+        block = bt_block.group(1)
+        pending: List[str] = []
+
+        for m in _TOKEN_RE.finditer(block):
+            lit, hex_s, arr, op = (
+                m.group(1), m.group(2), m.group(3), m.group(4)
+            )
+
+            if lit is not None:
+                pending.append(_decode_pdf_string(lit[1:-1]))
+            elif hex_s is not None:
+                pending.append(_decode_hex_string(hex_s[1:-1]))
+            elif arr is not None:
+                pending.append(_decode_tj_array(arr[1:-1]))
+            elif op in (b"Tj", b"TJ", b"'", b'"'):
+                parts.extend(pending)
+                pending.clear()
+            else:
+                # Any other operator resets the operand stack
+                pending.clear()
+
+    text = " ".join(p for p in parts if p.strip())
+    return re.sub(r" +", " ", text).strip()
+
+
+# ---------------------------------------------------------------------------
+# Main extractor class
+# ---------------------------------------------------------------------------
+
+class PDFExtractor:
+    """Extract text and metadata from a PDF file without external binaries.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the PDF file.
+    max_pages : int, optional
+        Stop after this many pages (0 = all pages, the default).
+
+    Examples
+    --------
+    >>> extractor = PDFExtractor("paper.pdf")
+    >>> result = extractor.extract()
+    >>> print(result.full_text[:200])
+    """
+
+    def __init__(self, path: str, max_pages: int = 0) -> None:
+        self.path = Path(path)
+        self.max_pages = max_pages
+        self._data: bytes = b""
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        """Read the PDF bytes and validate the magic number."""
+        if not self.path.is_file():
+            raise PDFParseError(f"File not found: {self.path}")
+        self._data = self.path.read_bytes()
+        if not self._data.startswith(b"%PDF"):
+            raise PDFParseError(f"Not a valid PDF file: {self.path}")
+
+    def _get_page_ids(self, xref: Dict[int, int]) -> List[int]:
+        """Return document-order page object IDs.
+
+        Tries the ``/Pages`` tree first; falls back to scanning all objects
+        for ``/Type /Page`` entries (handles malformed page trees).
+        """
+        pages_root = _find_pages_root(self._data, xref)
+        if pages_root is not None:
+            ids = _collect_page_ids(self._data, xref, pages_root)
+            if ids:
+                return ids
+        # Fallback: linear scan in object-ID order
+        ids = []
+        for obj_id in sorted(xref.keys()):
+            try:
+                _, body = _parse_obj_at(self._data, xref[obj_id])
+                if re.search(rb"/Type\s*/Page\b", body):
+                    ids.append(obj_id)
+            except PDFParseError:
+                continue
+        return ids
+
+    def _get_content_stream(
+        self, page_id: int, xref: Dict[int, int]
+    ) -> Optional[bytes]:
+        """Return the concatenated content stream(s) for a page object.
+
+        A page's ``/Contents`` value may be a single indirect reference or an
+        array of references; both forms are handled.
+        """
+        try:
+            _, page_body = _parse_obj_at(self._data, xref[page_id])
+        except PDFParseError:
+            return None
+
+        # /Contents may be "5 0 R" or "[5 0 R 6 0 R ...]"
+        contents_m = re.search(
+            rb"/Contents\s*([\d\s\[\]R]+)", page_body
+        )
+        if not contents_m:
+            return None
+
+        ref_str = contents_m.group(1).strip()
+        if ref_str.startswith(b"["):
+            ref_str = ref_str[1:].split(b"]")[0]
+
+        streams: List[bytes] = []
+        for ref_m in re.finditer(rb"(\d+)\s+\d+\s+R", ref_str):
+            ref_id = int(ref_m.group(1))
+            if ref_id not in xref:
+                continue
+            try:
+                _, ref_body = _parse_obj_at(self._data, xref[ref_id])
+                s = _extract_stream_bytes(ref_body)
+                if s is not None:
+                    streams.append(s)
+            except PDFParseError:
+                continue
+
+        # Some PDFs embed the content stream directly in the page object
+        if not streams:
+            s = _extract_stream_bytes(page_body)
+            if s is not None:
+                streams.append(s)
+
+        return b"\n".join(streams) if streams else None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def extract(self) -> ExtractionResult:
+        """Run the extraction pipeline.
+
+        Returns
+        -------
+        ExtractionResult
+            Structured result containing per-page text, document metadata,
+            and any non-fatal errors encountered.
+
+        Raises
+        ------
+        PDFParseError
+            If the file is missing or does not begin with ``%PDF``.
+        """
+        self._load()
+        result = ExtractionResult(source=self.path.name, page_count=0)
+
+        try:
+            xref = _load_full_xref(self._data)
+        except PDFParseError as exc:
+            result.errors.append(f"xref error: {exc}")
+            return result
+
+        result.metadata = _extract_metadata(self._data, xref)
+
+        page_ids = self._get_page_ids(xref)
+        if self.max_pages:
+            page_ids = page_ids[: self.max_pages]
+
+        pages: List[PageResult] = []
+        for page_num, page_id in enumerate(page_ids, start=1):
+            stream = self._get_content_stream(page_id, xref)
+            if stream is None:
+                pages.append(PageResult(page_number=page_num, text=""))
+                continue
+            try:
+                text = _extract_text_from_stream(stream)
+            except Exception as exc:
+                result.errors.append(f"page {page_num}: {exc}")
+                text = ""
+            pages.append(PageResult(page_number=page_num, text=text))
+
+        result.pages = pages
+        result.page_count = len(pages)
+        return result

--- a/src/pdfextract/gui.py
+++ b/src/pdfextract/gui.py
@@ -1,0 +1,255 @@
+"""Graphical user interface for pdfextract (requires tkinter).
+
+Launch with the ``pdfextract-gui`` command or::
+
+    python -m pdfextract.gui
+"""
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from typing import Optional
+
+try:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox, scrolledtext, ttk
+    _TKINTER_AVAILABLE = True
+except ImportError:
+    _TKINTER_AVAILABLE = False
+
+from . import __version__
+from .extractor import PDFExtractor, PDFParseError
+from .schema import ExtractionResult
+
+
+def _require_tkinter() -> None:
+    if not _TKINTER_AVAILABLE:
+        raise RuntimeError(
+            "tkinter is not available in this Python installation.\n"
+            "On Debian/Ubuntu: sudo apt-get install python3-tk\n"
+            "On Fedora/RHEL:   sudo dnf install python3-tkinter\n"
+            "On macOS/Windows: tkinter is bundled with standard Python."
+        )
+
+
+class PDFExtractorGUI:
+    """Main application window for the pdfextract GUI.
+
+    Parameters
+    ----------
+    root:
+        Parent ``tk.Tk`` window.
+    """
+
+    def __init__(self, root: "tk.Tk") -> None:
+        _require_tkinter()
+        self.root = root
+        self.root.title(f"pdfextract {__version__} — PDF Text Extractor")
+        self.root.minsize(720, 520)
+        self._result: Optional[ExtractionResult] = None
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(2, weight=1)
+
+        # ── Input ──────────────────────────────────────────────────────
+        input_frame = ttk.LabelFrame(self.root, text="Input PDF", padding=8)
+        input_frame.grid(row=0, column=0, sticky="ew", padx=10, pady=(10, 4))
+        input_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(input_frame, text="File:").grid(row=0, column=0, sticky="w")
+        self.file_var = tk.StringVar()
+        ttk.Entry(input_frame, textvariable=self.file_var).grid(
+            row=0, column=1, sticky="ew", padx=(6, 4)
+        )
+        ttk.Button(input_frame, text="Browse…", command=self._browse).grid(
+            row=0, column=2
+        )
+
+        # ── Options ────────────────────────────────────────────────────
+        opt_frame = ttk.LabelFrame(self.root, text="Options", padding=8)
+        opt_frame.grid(row=1, column=0, sticky="ew", padx=10, pady=4)
+
+        ttk.Label(opt_frame, text="Format:").grid(row=0, column=0, sticky="w")
+        self.fmt_var = tk.StringVar(value="text")
+        ttk.Combobox(
+            opt_frame,
+            textvariable=self.fmt_var,
+            values=["text", "markdown", "json"],
+            state="readonly",
+            width=12,
+        ).grid(row=0, column=1, sticky="w", padx=(6, 20))
+
+        ttk.Label(opt_frame, text="Max pages (0 = all):").grid(
+            row=0, column=2, sticky="w"
+        )
+        self.max_pages_var = tk.IntVar(value=0)
+        ttk.Spinbox(
+            opt_frame,
+            from_=0,
+            to=9999,
+            textvariable=self.max_pages_var,
+            width=6,
+        ).grid(row=0, column=3, sticky="w", padx=(6, 20))
+
+        self.extract_btn = ttk.Button(
+            opt_frame, text="Extract", command=self._start_extract
+        )
+        self.extract_btn.grid(row=0, column=4, padx=(10, 0))
+
+        # ── Output ─────────────────────────────────────────────────────
+        out_frame = ttk.LabelFrame(self.root, text="Output", padding=8)
+        out_frame.grid(row=2, column=0, sticky="nsew", padx=10, pady=4)
+        out_frame.columnconfigure(0, weight=1)
+        out_frame.rowconfigure(0, weight=1)
+
+        self.output_text = scrolledtext.ScrolledText(
+            out_frame,
+            wrap=tk.WORD,
+            font=("Courier", 10),
+            state=tk.DISABLED,
+        )
+        self.output_text.grid(row=0, column=0, sticky="nsew")
+
+        btn_bar = ttk.Frame(out_frame)
+        btn_bar.grid(row=1, column=0, sticky="ew", pady=(4, 0))
+        ttk.Button(btn_bar, text="Save output…", command=self._save).pack(
+            side=tk.LEFT
+        )
+        ttk.Button(btn_bar, text="Clear", command=self._clear).pack(
+            side=tk.LEFT, padx=6
+        )
+
+        # ── Status bar ─────────────────────────────────────────────────
+        status_frame = ttk.Frame(self.root)
+        status_frame.grid(row=3, column=0, sticky="ew")
+        status_frame.columnconfigure(0, weight=1)
+
+        self.status_var = tk.StringVar(value="Ready")
+        ttk.Label(
+            status_frame,
+            textvariable=self.status_var,
+            relief=tk.SUNKEN,
+            anchor=tk.W,
+            padding=(4, 2),
+        ).grid(row=0, column=0, sticky="ew")
+
+        self.progress = ttk.Progressbar(status_frame, mode="indeterminate", length=120)
+        self.progress.grid(row=0, column=1, padx=(4, 2), pady=2)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select a PDF file",
+            filetypes=[("PDF files", "*.pdf"), ("All files", "*.*")],
+        )
+        if path:
+            self.file_var.set(path)
+
+    def _start_extract(self) -> None:
+        path = self.file_var.get().strip()
+        if not path:
+            messagebox.showwarning("No file selected", "Please select a PDF file first.")
+            return
+        if not Path(path).is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+
+        self.extract_btn.config(state=tk.DISABLED)
+        self.progress.start(10)
+        self._set_status("Extracting…")
+        self._clear()
+        threading.Thread(
+            target=self._extract_worker, args=(path,), daemon=True
+        ).start()
+
+    def _extract_worker(self, path: str) -> None:
+        try:
+            extractor = PDFExtractor(path, max_pages=self.max_pages_var.get())
+            result = extractor.extract()
+            self._result = result
+
+            fmt = self.fmt_var.get()
+            if fmt == "json":
+                text = result.to_json()
+            elif fmt == "markdown":
+                text = result.to_markdown()
+            else:
+                text = result.full_text or "(No text could be extracted from this PDF.)"
+
+            summary = f"Done — {result.page_count} page(s), {result.word_count} word(s)"
+            if result.errors:
+                summary += f", {len(result.errors)} warning(s)"
+
+            self.root.after(0, self._on_done, text, summary)
+        except PDFParseError as exc:
+            self.root.after(0, self._on_error, str(exc))
+        except Exception as exc:
+            self.root.after(0, self._on_error, f"Unexpected error: {exc}")
+
+    def _on_done(self, text: str, summary: str) -> None:
+        self._write_output(text)
+        self._set_status(summary)
+        self.progress.stop()
+        self.extract_btn.config(state=tk.NORMAL)
+
+    def _on_error(self, message: str) -> None:
+        self._set_status(f"Error: {message}")
+        self.progress.stop()
+        self.extract_btn.config(state=tk.NORMAL)
+        messagebox.showerror("Extraction error", message)
+
+    def _save(self) -> None:
+        content = self.output_text.get("1.0", tk.END).strip()
+        if not content:
+            messagebox.showinfo("Nothing to save", "Extract a PDF first.")
+            return
+        fmt = self.fmt_var.get()
+        ext = {"text": ".txt", "markdown": ".md", "json": ".json"}.get(fmt, ".txt")
+        path = filedialog.asksaveasfilename(
+            defaultextension=ext,
+            filetypes=[
+                ("Text files", "*.txt"),
+                ("Markdown files", "*.md"),
+                ("JSON files", "*.json"),
+                ("All files", "*.*"),
+            ],
+        )
+        if path:
+            Path(path).write_text(content, encoding="utf-8")
+            self._set_status(f"Saved to {path}")
+
+    def _clear(self) -> None:
+        self.output_text.config(state=tk.NORMAL)
+        self.output_text.delete("1.0", tk.END)
+        self.output_text.config(state=tk.DISABLED)
+
+    def _write_output(self, text: str) -> None:
+        self.output_text.config(state=tk.NORMAL)
+        self.output_text.delete("1.0", tk.END)
+        self.output_text.insert(tk.END, text)
+        self.output_text.config(state=tk.DISABLED)
+
+    def _set_status(self, message: str) -> None:
+        self.status_var.set(message)
+
+
+def main() -> None:
+    """Launch the pdfextract graphical interface."""
+    _require_tkinter()
+    root = tk.Tk()
+    PDFExtractorGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdfextract/schema.py
+++ b/src/pdfextract/schema.py
@@ -1,0 +1,122 @@
+"""Data model for pdfextract extraction results."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class PageResult:
+    """Extraction result for a single PDF page.
+
+    Parameters
+    ----------
+    page_number:
+        1-based page index.
+    text:
+        Extracted plain text for this page.
+    """
+
+    page_number: int
+    text: str
+    word_count: int = field(init=False)
+    char_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.word_count = len(self.text.split())
+        self.char_count = len(self.text)
+
+
+@dataclass
+class ExtractionResult:
+    """Full extraction result for a PDF document.
+
+    Parameters
+    ----------
+    source:
+        File name (not full path) of the source PDF.
+    page_count:
+        Total number of pages processed.
+    pages:
+        Per-page extraction results in document order.
+    metadata:
+        Document metadata from the PDF /Info dictionary
+        (Title, Author, Subject, Keywords, Creator, Producer, CreationDate).
+    errors:
+        Non-fatal warnings / errors encountered during extraction.
+    """
+
+    source: str
+    page_count: int
+    pages: List[PageResult] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Computed properties
+    # ------------------------------------------------------------------
+
+    @property
+    def full_text(self) -> str:
+        """All page texts joined by a blank line."""
+        return "\n\n".join(p.text for p in self.pages if p.text.strip())
+
+    @property
+    def word_count(self) -> int:
+        """Total word count across all pages."""
+        return sum(p.word_count for p in self.pages)
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable dictionary."""
+        return {
+            "source": self.source,
+            "page_count": self.page_count,
+            "word_count": self.word_count,
+            "metadata": self.metadata,
+            "errors": self.errors,
+            "pages": [
+                {
+                    "page": p.page_number,
+                    "text": p.text,
+                    "words": p.word_count,
+                    "chars": p.char_count,
+                }
+                for p in self.pages
+            ],
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialise to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    def to_markdown(self) -> str:
+        """Render extraction result as a Markdown document."""
+        lines: List[str] = [
+            f"# Extracted Text: {self.source}",
+            "",
+            f"**Pages**: {self.page_count} | **Words**: {self.word_count}",
+            "",
+        ]
+        if self.metadata:
+            lines += ["## Metadata", ""]
+            for key, value in self.metadata.items():
+                lines.append(f"- **{key}**: {value}")
+            lines.append("")
+        if self.errors:
+            lines += ["## Warnings", ""]
+            for err in self.errors:
+                lines.append(f"- {err}")
+            lines.append("")
+        for page in self.pages:
+            lines += [
+                f"## Page {page.page_number}",
+                "",
+                page.text if page.text.strip() else "*No text extracted from this page.*",
+                "",
+            ]
+        return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+"""Pytest configuration: add src/ to sys.path for editable installs."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/test_pdfextract.py
+++ b/tests/test_pdfextract.py
@@ -1,18 +1,485 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""Test suite for pdfextract.
 
-def test_import():
-    import pdfextract
-    assert hasattr(pdfextract, 'extract_pdf')
+Tests are split into four groups:
+1. Public API / import tests
+2. Data model (PageResult, ExtractionResult)
+3. Low-level parser utilities
+4. PDFExtractor error handling (no real PDF required)
 
-def test_pdf_parse_error():
-    import pdfextract
-    assert hasattr(pdfextract, 'PDFParseError')
+A synthetic minimal PDF is constructed in-process for end-to-end smoke tests.
+"""
+from __future__ import annotations
 
-def test_page_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'PageResult')
+import json
+import zlib
+from pathlib import Path
 
-def test_extraction_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'ExtractionResult')
+import pytest
+
+# Public API surface
+import pdfextract
+from pdfextract import (
+    PDFExtractor,
+    PDFParseError,
+    ExtractionResult,
+    PageResult,
+    extract_pdf,
+)
+from pdfextract.extractor import (
+    _decode_pdf_string,
+    _decode_hex_string,
+    _find_startxref,
+    _parse_xref_table,
+    _extract_text_from_stream,
+    _decode_tj_array,
+    _decompress,
+    _parse_obj_at,
+)
+from pdfextract.schema import PageResult, ExtractionResult
+
+
+# ===========================================================================
+# 1. Public API / import
+# ===========================================================================
+
+class TestPublicAPI:
+    def test_version_attribute(self):
+        assert hasattr(pdfextract, "__version__")
+        assert isinstance(pdfextract.__version__, str)
+        assert pdfextract.__version__.count(".") >= 1
+
+    def test_all_symbols_exported(self):
+        for name in ("extract_pdf", "PDFParseError", "PageResult",
+                     "ExtractionResult", "PDFExtractor"):
+            assert hasattr(pdfextract, name), f"missing: {name}"
+
+    def test_extract_pdf_callable(self):
+        assert callable(pdfextract.extract_pdf)
+
+
+# ===========================================================================
+# 2. Data model
+# ===========================================================================
+
+class TestPageResult:
+    def test_word_count(self):
+        pr = PageResult(page_number=1, text="Hello world this is a test")
+        assert pr.word_count == 6
+
+    def test_char_count(self):
+        pr = PageResult(page_number=1, text="abc")
+        assert pr.char_count == 3
+
+    def test_empty_text(self):
+        pr = PageResult(page_number=1, text="")
+        assert pr.word_count == 0
+        assert pr.char_count == 0
+
+    def test_page_number_stored(self):
+        pr = PageResult(page_number=42, text="x")
+        assert pr.page_number == 42
+
+
+class TestExtractionResult:
+    def _make_result(self) -> ExtractionResult:
+        return ExtractionResult(
+            source="test.pdf",
+            page_count=2,
+            pages=[
+                PageResult(page_number=1, text="Page one has five words here"),
+                PageResult(page_number=2, text="Page two"),
+            ],
+            metadata={"Title": "Test Document", "Author": "Jane"},
+        )
+
+    def test_full_text_joins_pages(self):
+        r = self._make_result()
+        assert "Page one" in r.full_text
+        assert "Page two" in r.full_text
+
+    def test_word_count_sums_pages(self):
+        r = self._make_result()
+        assert r.word_count == 8  # 6 + 2
+
+    def test_to_dict_structure(self):
+        r = self._make_result()
+        d = r.to_dict()
+        assert d["source"] == "test.pdf"
+        assert d["page_count"] == 2
+        assert d["metadata"]["Title"] == "Test Document"
+        assert len(d["pages"]) == 2
+        assert d["pages"][0]["words"] == 6
+
+    def test_to_json_valid(self):
+        r = self._make_result()
+        data = json.loads(r.to_json())
+        assert data["source"] == "test.pdf"
+
+    def test_to_markdown_contains_headings(self):
+        r = self._make_result()
+        md = r.to_markdown()
+        assert "# Extracted Text: test.pdf" in md
+        assert "## Page 1" in md
+        assert "## Page 2" in md
+
+    def test_to_markdown_contains_metadata(self):
+        r = self._make_result()
+        md = r.to_markdown()
+        assert "**Title**" in md
+        assert "**Author**" in md
+
+    def test_to_markdown_empty_page_placeholder(self):
+        r = ExtractionResult(
+            source="x.pdf",
+            page_count=1,
+            pages=[PageResult(page_number=1, text="")],
+        )
+        md = r.to_markdown()
+        assert "No text extracted" in md
+
+    def test_errors_shown_in_markdown(self):
+        r = ExtractionResult(
+            source="x.pdf",
+            page_count=0,
+            errors=["page 1: decode error"],
+        )
+        md = r.to_markdown()
+        assert "Warnings" in md
+        assert "page 1: decode error" in md
+
+    def test_full_text_skips_blank_pages(self):
+        r = ExtractionResult(
+            source="x.pdf",
+            page_count=3,
+            pages=[
+                PageResult(page_number=1, text="Hello"),
+                PageResult(page_number=2, text="   "),
+                PageResult(page_number=3, text="World"),
+            ],
+        )
+        assert r.full_text == "Hello\n\nWorld"
+
+
+# ===========================================================================
+# 3. Low-level parser utilities
+# ===========================================================================
+
+class TestDecodePdfString:
+    def test_plain_ascii(self):
+        assert _decode_pdf_string(b"Hello World") == "Hello World"
+
+    def test_newline_escape(self):
+        assert _decode_pdf_string(b"A\\nB") == "A\nB"
+
+    def test_tab_escape(self):
+        assert _decode_pdf_string(b"A\\tB") == "A\tB"
+
+    def test_paren_escapes(self):
+        assert _decode_pdf_string(b"\\(ok\\)") == "(ok)"
+
+    def test_backslash_escape(self):
+        assert _decode_pdf_string(b"a\\\\b") == "a\\b"
+
+    def test_octal_three_digit(self):
+        # \101 = 'A'
+        assert _decode_pdf_string(b"\\101") == "A"
+
+    def test_octal_two_digit(self):
+        # \41 = '!'
+        assert _decode_pdf_string(b"\\41") == "!"
+
+    def test_empty(self):
+        assert _decode_pdf_string(b"") == ""
+
+
+class TestDecodeHexString:
+    def test_basic(self):
+        assert _decode_hex_string(b"48656c6c6f") == "Hello"
+
+    def test_with_spaces(self):
+        assert _decode_hex_string(b"48 65 6c 6c 6f") == "Hello"
+
+    def test_odd_length_padded(self):
+        # "4" → "40" → chr(0x40) = '@'
+        result = _decode_hex_string(b"4")
+        assert result == "@"
+
+    def test_empty(self):
+        assert _decode_hex_string(b"") == ""
+
+
+class TestFindStartxref:
+    def test_standard_trailer(self):
+        data = b"\x00" * 500 + b"\nstartxref\n12345\n%%EOF"
+        assert _find_startxref(data) == 12345
+
+    def test_missing_raises(self):
+        with pytest.raises(PDFParseError, match="startxref"):
+            _find_startxref(b"no xref marker at all in this data")
+
+    def test_near_end_of_file(self):
+        data = b"garbage" * 300 + b"startxref\n99\n%%EOF"
+        assert _find_startxref(data) == 99
+
+
+class TestParseXrefTable:
+    def _make_xref_bytes(self) -> bytes:
+        return (
+            b"xref\n"
+            b"0 4\n"
+            b"0000000000 65535 f \n"
+            b"0000000100 00000 n \n"
+            b"0000000200 00000 n \n"
+            b"0000000300 00000 n \n"
+            b"trailer\n<</Size 4>>\n"
+        )
+
+    def test_in_use_entries(self):
+        data = b"\x00" * 50 + self._make_xref_bytes()
+        offsets, prev = _parse_xref_table(data, 50)
+        assert offsets[1] == 100
+        assert offsets[2] == 200
+        assert offsets[3] == 300
+
+    def test_free_entry_excluded(self):
+        data = b"\x00" * 50 + self._make_xref_bytes()
+        offsets, _ = _parse_xref_table(data, 50)
+        assert 0 not in offsets
+
+    def test_no_prev(self):
+        data = b"\x00" * 50 + self._make_xref_bytes()
+        _, prev = _parse_xref_table(data, 50)
+        assert prev is None
+
+    def test_with_prev(self):
+        data = (
+            b"\x00" * 50
+            + b"xref\n0 1\n0000000000 65535 f \ntrailer\n<</Size 1 /Prev 42>>\n"
+        )
+        _, prev = _parse_xref_table(data, 50)
+        assert prev == 42
+
+
+class TestExtractTextFromStream:
+    def test_simple_tj(self):
+        stream = b"BT (Hello World) Tj ET"
+        assert "Hello" in _extract_text_from_stream(stream)
+        assert "World" in _extract_text_from_stream(stream)
+
+    def test_tj_array(self):
+        stream = b"BT [(Foo) -120 (Bar)] TJ ET"
+        text = _extract_text_from_stream(stream)
+        assert "Foo" in text
+        assert "Bar" in text
+
+    def test_large_negative_gap_becomes_space(self):
+        # A gap of -150 should insert a word space
+        stream = b"BT [(hello) -200 (world)] TJ ET"
+        text = _extract_text_from_stream(stream)
+        assert " " in text
+
+    def test_single_quote_operator(self):
+        stream = b"BT (Next line) ' ET"
+        assert "Next line" in _extract_text_from_stream(stream)
+
+    def test_hex_string_tj(self):
+        # <48656c6c6f> = "Hello"
+        stream = b"BT <48656c6c6f> Tj ET"
+        assert "Hello" in _extract_text_from_stream(stream)
+
+    def test_empty_stream(self):
+        assert _extract_text_from_stream(b"") == ""
+
+    def test_no_bt_et_block(self):
+        assert _extract_text_from_stream(b"(text) Tj") == ""
+
+    def test_multiple_bt_blocks(self):
+        stream = b"BT (Block one) Tj ET BT (Block two) Tj ET"
+        text = _extract_text_from_stream(stream)
+        assert "Block one" in text
+        assert "Block two" in text
+
+
+class TestDecodeTjArray:
+    def test_simple_strings(self):
+        result = _decode_tj_array(b"(foo)(bar)")
+        assert result == "foobar"
+
+    def test_space_inserted_for_large_gap(self):
+        result = _decode_tj_array(b"(foo) -150 (bar)")
+        assert result == "foo bar"
+
+    def test_small_gap_no_space(self):
+        result = _decode_tj_array(b"(foo) -50 (bar)")
+        assert result == "foobar"
+
+
+class TestDecompress:
+    def test_roundtrip(self):
+        original = b"Hello, compressed world!" * 10
+        compressed = zlib.compress(original)
+        assert _decompress(compressed) == original
+
+    def test_invalid_returns_raw(self):
+        raw = b"not compressed data"
+        assert _decompress(raw) == raw
+
+
+class TestParseObjAt:
+    def test_basic_obj(self):
+        data = b"\x00" * 20 + b"5 0 obj\n<</Type /Page>>\nendobj\n"
+        obj_id, body = _parse_obj_at(data, 20)
+        assert obj_id == 5
+        assert b"/Type /Page" in body
+
+    def test_missing_obj_raises(self):
+        with pytest.raises(PDFParseError, match="obj marker"):
+            _parse_obj_at(b"no object here", 0)
+
+
+# ===========================================================================
+# 4. PDFExtractor error handling
+# ===========================================================================
+
+class TestPDFExtractorErrors:
+    def test_not_a_pdf_raises(self, tmp_path):
+        bad = tmp_path / "bad.pdf"
+        bad.write_bytes(b"This is definitely not a PDF file.")
+        with pytest.raises(PDFParseError, match="valid PDF"):
+            PDFExtractor(str(bad)).extract()
+
+    def test_file_not_found_raises(self, tmp_path):
+        missing = tmp_path / "missing.pdf"
+        with pytest.raises(PDFParseError, match="not found"):
+            PDFExtractor(str(missing)).extract()
+
+    def test_extract_pdf_propagates_error(self, tmp_path):
+        bad = tmp_path / "bad.pdf"
+        bad.write_bytes(b"garbage")
+        with pytest.raises(PDFParseError):
+            extract_pdf(str(bad))
+
+    def test_missing_xref_returns_error_result(self, tmp_path):
+        # Valid magic but no real xref — extraction returns with errors
+        trunc = tmp_path / "trunc.pdf"
+        trunc.write_bytes(b"%PDF-1.4\n%%EOF\n")
+        result = PDFExtractor(str(trunc)).extract()
+        assert result.page_count == 0
+        assert len(result.errors) > 0
+
+
+# ===========================================================================
+# 5. End-to-end smoke test with a synthetic minimal PDF
+# ===========================================================================
+
+def _build_minimal_pdf(text: str = "Hello from pdfextract") -> bytes:
+    """Build the smallest valid PDF that contains one page with visible text.
+
+    The PDF embeds a single content stream with a BT/ET block whose string
+    is encoded as a PDF literal.  No fonts are declared (viewers will
+    substitute a default), but pdfextract only needs the byte stream.
+    """
+    # Escape the text for a PDF literal string
+    escaped = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    content = f"BT /F1 12 Tf 100 700 Td ({escaped}) Tj ET\n".encode()
+    compressed = zlib.compress(content)
+
+    objects: list[bytes] = []
+
+    def obj(n: int, body: bytes) -> bytes:
+        return f"{n} 0 obj\n".encode() + body + b"\nendobj\n"
+
+    # Object 1: Catalogue
+    objects.append(obj(1, b"<</Type /Catalog /Pages 2 0 R>>"))
+    # Object 2: Pages node
+    objects.append(obj(2, b"<</Type /Pages /Kids [3 0 R] /Count 1>>"))
+    # Object 3: Page
+    objects.append(obj(3, b"<</Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R>>"))
+    # Object 4: Content stream (FlateDecode)
+    stream_dict = (
+        f"<</Length {len(compressed)} /Filter /FlateDecode>>\n".encode()
+        + b"stream\n"
+        + compressed
+        + b"\nendstream"
+    )
+    objects.append(obj(4, stream_dict))
+
+    # Assemble: header + objects, record byte offsets for xref
+    header = b"%PDF-1.4\n"
+    body = bytearray(header)
+    offsets: list[int] = []
+    for o in objects:
+        offsets.append(len(body))
+        body.extend(o)
+
+    xref_offset = len(body)
+    xref = bytearray(b"xref\n")
+    xref.extend(f"0 {len(objects) + 1}\n".encode())
+    xref.extend(b"0000000000 65535 f \n")
+    for off in offsets:
+        xref.extend(f"{off:010d} 00000 n \n".encode())
+
+    trailer = (
+        f"trailer\n<</Size {len(objects) + 1} /Root 1 0 R>>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    ).encode()
+
+    return bytes(body) + bytes(xref) + trailer
+
+
+class TestEndToEnd:
+    def test_synthetic_pdf_text_extraction(self, tmp_path):
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf("Synthetic test document"))
+
+        result = PDFExtractor(str(pdf_path)).extract()
+
+        assert result.page_count == 1
+        assert "Synthetic" in result.full_text or result.full_text != ""
+
+    def test_synthetic_pdf_max_pages(self, tmp_path):
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf())
+
+        result = PDFExtractor(str(pdf_path), max_pages=0).extract()
+        assert result.page_count >= 1
+
+    def test_extract_pdf_text_format(self, tmp_path):
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf("Format test"))
+
+        out = extract_pdf(str(pdf_path), output_format="text")
+        assert isinstance(out, str)
+
+    def test_extract_pdf_json_format(self, tmp_path):
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf())
+
+        out = extract_pdf(str(pdf_path), output_format="json")
+        data = json.loads(out)
+        assert "pages" in data
+        assert "metadata" in data
+
+    def test_extract_pdf_markdown_format(self, tmp_path):
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf())
+
+        out = extract_pdf(str(pdf_path), output_format="markdown")
+        assert "# Extracted Text" in out
+
+    def test_extract_pdf_writes_output_file(self, tmp_path):
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf())
+        out_path = tmp_path / "output.txt"
+
+        extract_pdf(str(pdf_path), output_path=str(out_path))
+        assert out_path.exists()
+        assert out_path.stat().st_size > 0
+
+    def test_result_source_is_filename(self, tmp_path):
+        pdf_path = tmp_path / "myfile.pdf"
+        pdf_path.write_bytes(_build_minimal_pdf())
+
+        result = PDFExtractor(str(pdf_path)).extract()
+        assert result.source == "myfile.pdf"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Package restructure**: migrated from single root `pdfextract.py` to a proper `src/pdfextract/` layout (`schema.py`, `extractor.py`, `cli.py`, `gui.py`) required for JOSS submission
- **Bug fixes**: xref table read window enlarged (4 KB → 1 MiB), PDF 1.5+ xref stream support, correct document-order page traversal via `/Pages` tree, multi-stream `/Contents` arrays, safe octal escape parsing, word-boundary BT/ET regex
- **New features**: metadata extraction from `/Info`, tkinter GUI (`pdfextract-gui`), `to_json()` helper, TJ kerning-gap word-space heuristic
- **Tests**: 61-test suite covering public API, data model, low-level parser utilities, error handling, and an end-to-end synthetic-PDF smoke test (was 4 tests)
- **Docs**: complete README, accurate `paper.md` (no longer references unused `pdfminer.six`/`camelot` deps), CHANGELOG

## Test plan

- [ ] `pytest tests/ -v` — all 61 tests pass
- [ ] `pip install -e . && pdfextract --help` — CLI works
- [ ] `pip install -e . && pdfextract-gui` — GUI launches (requires Python 3.12 + tkinter)
- [ ] Extract a real PDF with `pdfextract paper.pdf -f json` and inspect output

https://claude.ai/code/session_01N58NG5zcaiUTMzoCqMr4cP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N58NG5zcaiUTMzoCqMr4cP)_