### PR TITLE
feat: fix parser bugs, restructure to src layout, add GUI (JOSS-level)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.so

--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
 # pdfextract
+
+Pure-Python PDF text and metadata extractor — no external binaries required.
+
+Reads cross-reference tables, resolves page-content object references, decodes
+FlateDecode streams, and outputs plain text, Markdown, or JSON. Ships with a
+command-line interface and a Tkinter GUI.
+
+## Installation
+
+```bash
+pip install .
+```
+
+Requires Python ≥ 3.8. No third-party runtime dependencies.
+
+## CLI
+
+```bash
+# Single file — print to stdout
+pdfextract paper.pdf
+
+# Save as Markdown
+pdfextract paper.pdf -f markdown -o paper.md
+
+# JSON output, first 5 pages only
+pdfextract paper.pdf -f json -p 5 -o paper.json
+
+# Batch — write .txt files into ./out/
+pdfextract *.pdf -o out/
+```
+
+```
+usage: pdfextract [-h] [-o OUTPUT] [-f {text,markdown,json}] [-p N] input [input ...]
+```
+
+## GUI
+
+```bash
+pdfextract-gui
+```
+
+Opens a desktop window: browse for a PDF, choose format, click **Extract**,
+then **Save** the result.
+
+## Python API
+
+```python
+from pdfextract import PDFExtractor, extract_pdf, extract_batch
+
+# Simple one-liner
+text = extract_pdf("paper.pdf")
+
+# Full result object
+result = PDFExtractor("paper.pdf").extract()
+print(result.metadata)          # {'Title': '...', 'Author': '...'}
+print(result.page_count)
+print(result.pages[0].text)
+print(result.to_markdown())
+
+# Batch
+results = extract_batch(["a.pdf", "b.pdf"], output_format="json", output_dir="out/")
+```
+
+### ExtractionResult
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `source` | `str` | Filename |
+| `page_count` | `int` | Number of pages extracted |
+| `pages` | `list[PageResult]` | Per-page text and word counts |
+| `metadata` | `dict[str, str]` | PDF Info dictionary (Title, Author, …) |
+| `errors` | `list[str]` | Non-fatal parse warnings |
+| `full_text` | `str` | All pages joined |
+| `word_count` | `int` | Total words |
+| `to_dict()` | | JSON-serialisable dict |
+| `to_json()` | | JSON string |
+| `to_markdown()` | | Markdown string |
+
+## Limitations
+
+- Encrypted PDFs are not supported.
+- Cross-reference streams (PDF 1.5+, common in newer tools) fall back to an
+  object-scan heuristic; text is still extracted in most cases.
+- CIDFont / ToUnicode glyph mapping is not implemented; non-Latin text may
+  appear garbled.
+
+## Testing
+
+```bash
+pip install pytest
+pytest tests/
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/pdfextract.py
+++ b/pdfextract.py
@@ -1,370 +1,79 @@
 """
-pdfextract: Extract structured text, tables, and metadata from PDF files.
+pdfextract – backward-compatibility shim.
 
-Pure-Python PDF parser (no external binaries required) that reads cross-reference
-tables, decodes content streams, extracts text runs with page/position metadata,
-detects table regions via whitespace analysis, and outputs plain text, Markdown,
-or JSON. Falls back gracefully on encrypted or malformed PDFs.
+The canonical implementation lives in ``src/pdfextract/``.
+This module re-exports everything so that scripts which import
+``pdfextract`` directly (without installing the package) still work.
 """
 from __future__ import annotations
-import re, struct, zlib, json
-from dataclasses import dataclass, field
+import sys
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple
 
+# Make src/ importable when running the file directly
+_src = Path(__file__).parent / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
 
-# ---------------------------------------------------------------------------
-# PDF low-level parser (supports PDF 1.x; no encryption)
-# ---------------------------------------------------------------------------
-
-class PDFParseError(Exception):
-    pass
-
-
-def _read_bytes(path: Path) -> bytes:
-    return path.read_bytes()
-
-
-def _find_xref_offset(data: bytes) -> int:
-    """Locate startxref offset from end of file."""
-    tail = data[-1024:]
-    m = re.search(rb"startxref\s+(\d+)", tail)
-    if not m:
-        raise PDFParseError("startxref not found.")
-    return int(m.group(1))
-
-
-def _parse_xref_table(data: bytes, offset: int) -> Dict[int, int]:
-    """Parse a classic xref table. Returns {obj_id: byte_offset}."""
-    offsets: Dict[int, int] = {}
-    pos = offset
-    # skip 'xref'
-    chunk = data[pos:pos + 4096].decode("latin-1", errors="replace")
-    lines = chunk.splitlines()
-    i = 0
-    if lines[i].strip() == "xref":
-        i += 1
-    while i < len(lines):
-        header = lines[i].strip()
-        m = re.match(r"(\d+)\s+(\d+)", header)
-        if not m:
-            break
-        first_obj = int(m.group(1))
-        count = int(m.group(2))
-        i += 1
-        for j in range(count):
-            if i >= len(lines):
-                break
-            entry = lines[i].strip()
-            i += 1
-            parts = entry.split()
-            if len(parts) < 3:
-                continue
-            byte_off, gen, kind = parts[0], parts[1], parts[2]
-            obj_id = first_obj + j
-            if kind == "n":
-                offsets[obj_id] = int(byte_off)
-    return offsets
-
-
-def _parse_obj(data: bytes, byte_off: int) -> Tuple[int, bytes]:
-    """Extract the raw bytes of one indirect object."""
-    chunk = data[byte_off:byte_off + 65536]
-    m = re.search(rb"(\d+)\s+(\d+)\s+obj", chunk)
-    if not m:
-        raise PDFParseError("obj marker not found at offset " + str(byte_off))
-    start = m.end()
-    # find matching endobj
-    end_m = re.search(rb"endobj", chunk[start:])
-    if not end_m:
-        return int(m.group(1)), chunk[start:]
-    return int(m.group(1)), chunk[start:start + end_m.start()]
-
-
-def _decode_flate(raw: bytes) -> bytes:
-    try:
-        return zlib.decompress(raw)
-    except zlib.error:
-        try:
-            return zlib.decompress(raw, -15)
-        except zlib.error:
-            return raw
-
-
-def _extract_stream(obj_bytes: bytes) -> Optional[bytes]:
-    """Extract and decompress a PDF stream from an object body."""
-    m = re.search(rb"stream\r?\n", obj_bytes)
-    if not m:
-        return None
-    stream_start = m.end()
-    end_m = re.search(rb"endstream", obj_bytes[stream_start:])
-    raw = obj_bytes[stream_start:stream_start + (end_m.start() if end_m else len(obj_bytes))]
-    # Check for FlateDecode
-    if b"FlateDecode" in obj_bytes[:stream_start]:
-        raw = _decode_flate(raw)
-    return raw
-
-
-# ---------------------------------------------------------------------------
-# Text extraction from content streams
-# ---------------------------------------------------------------------------
-
-_TEXT_OPS = re.compile(
-    rb"\(([^)\\]|\\.)*\)\s*Tj"       # (text) Tj
-    rb"|\[([^\]]+)\]\s*TJ"               # [array] TJ
+from pdfextract import (  # noqa: E402  (import not at top)
+    PDFExtractor,
+    ExtractionResult,
+    PageResult,
+    PDFParseError,
+    extract_pdf,
+    extract_batch,
 )
 
-_BT_ET = re.compile(rb"BT(.+?)ET", re.DOTALL)
-_STRING_RE = re.compile(rb"\(([^)\\]|\\.)*\)")
+__all__ = [
+    "PDFExtractor",
+    "ExtractionResult",
+    "PageResult",
+    "PDFParseError",
+    "extract_pdf",
+    "extract_batch",
+]
 
-
-def _decode_pdf_string(s: bytes) -> str:
-    """Decode a PDF literal string, handling \ooo octal and common escapes."""
-    out = []
-    i = 0
-    while i < len(s):
-        c = s[i:i+1]
-        if c == b"\\":
-            i += 1
-            nc = s[i:i+1]
-            if nc in (b"n",):   out.append("\n")
-            elif nc in (b"r",): out.append("\r")
-            elif nc in (b"t",): out.append("\t")
-            elif nc in (b"(",): out.append("(")
-            elif nc in (b")",): out.append(")")
-            elif nc.isdigit():
-                octal = s[i:i+3]
-                out.append(chr(int(octal, 8)))
-                i += 2
-            else:
-                out.append(nc.decode("latin-1", errors="replace"))
-        else:
-            out.append(c.decode("latin-1", errors="replace"))
-        i += 1
-    return "".join(out)
-
-
-def _extract_text_from_stream(stream: bytes) -> str:
-    """Pull text from a PDF content stream using simple BT/ET block parsing."""
-    parts: List[str] = []
-    for bt_block in _BT_ET.finditer(stream):
-        block = bt_block.group(1)
-        for string_m in _STRING_RE.finditer(block):
-            raw = string_m.group(0)[1:-1]  # strip parens
-            parts.append(_decode_pdf_string(raw))
-        # Also catch bare TJ arrays
-        for tj_m in re.finditer(rb"\[([^\]]+)\]\s*TJ", block):
-            inner = tj_m.group(1)
-            for s in _STRING_RE.finditer(inner):
-                raw = s.group(0)[1:-1]
-                parts.append(_decode_pdf_string(raw))
-    return " ".join(p.strip() for p in parts if p.strip())
-
-
-# ---------------------------------------------------------------------------
-# Data model
-# ---------------------------------------------------------------------------
-
-@dataclass
-class PageResult:
-    page_number: int          # 1-based
-    text: str
-    word_count: int = 0
-    char_count: int = 0
-
-    def __post_init__(self):
-        self.word_count = len(self.text.split())
-        self.char_count = len(self.text)
-
-
-@dataclass
-class ExtractionResult:
-    source: str
-    page_count: int
-    pages: List[PageResult] = field(default_factory=list)
-    metadata: Dict[str, str] = field(default_factory=dict)
-    errors: List[str] = field(default_factory=list)
-
-    @property
-    def full_text(self) -> str:
-        return "\n\n".join(p.text for p in self.pages if p.text.strip())
-
-    @property
-    def word_count(self) -> int:
-        return sum(p.word_count for p in self.pages)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "source": self.source,
-            "page_count": self.page_count,
-            "word_count": self.word_count,
-            "metadata": self.metadata,
-            "errors": self.errors,
-            "pages": [{"page": p.page_number, "text": p.text,
-                       "words": p.word_count} for p in self.pages],
-        }
-
-    def to_markdown(self) -> str:
-        lines = [
-            "# Extracted Text: " + self.source, "",
-            "**Pages**: " + str(self.page_count) + " | **Words**: " + str(self.word_count), "",
-        ]
-        if self.metadata:
-            lines += ["## Metadata", ""]
-            for k, v in self.metadata.items():
-                lines.append("- **" + k + "**: " + v)
-            lines.append("")
-        for page in self.pages:
-            lines += [
-                "## Page " + str(page.page_number), "",
-                page.text, "",
-            ]
-        return "\n".join(lines)
-
-
-# ---------------------------------------------------------------------------
-# Main extractor
-# ---------------------------------------------------------------------------
-
-class PDFExtractor:
-    """
-    Extract text and metadata from a PDF file without external binaries.
-
-    Parameters
-    ----------
-    path : str
-        Path to the PDF file.
-    max_pages : int, optional
-        Stop after this many pages. 0 = all pages.
-    """
-
-    def __init__(self, path: str, max_pages: int = 0) -> None:
-        self.path = Path(path)
-        self.max_pages = max_pages
-        self._data: bytes = b""
-
-    def _load(self) -> None:
-        self._data = _read_bytes(self.path)
-        magic = self._data[:4]
-        if magic != b"%PDF":
-            raise PDFParseError("Not a PDF file: " + str(self.path))
-
-    def _get_xref(self) -> Dict[int, int]:
-        offset = _find_xref_offset(self._data)
-        return _parse_xref_table(self._data, offset)
-
-    def _get_page_streams(self, xref: Dict[int, int]) -> Iterator[Tuple[int, bytes]]:
-        """Yield (page_index, content_stream_bytes)."""
-        page_num = 0
-        for obj_id in sorted(xref.keys()):
-            byte_off = xref[obj_id]
-            try:
-                _, obj_body = _parse_obj(self._data, byte_off)
-            except PDFParseError:
-                continue
-            # Heuristic: objects containing /Type /Page with /Contents
-            if b"/Type /Page" in obj_body or b"/Type\n/Page" in obj_body:
-                stream = _extract_stream(obj_body)
-                if stream:
-                    page_num += 1
-                    yield page_num, stream
-                    if self.max_pages and page_num >= self.max_pages:
-                        return
-
-    def extract(self) -> ExtractionResult:
-        """Run extraction. Returns ExtractionResult."""
-        self._load()
-        result = ExtractionResult(source=self.path.name, page_count=0)
-        errors: List[str] = []
-        try:
-            xref = self._get_xref()
-        except PDFParseError as exc:
-            result.errors.append("xref error: " + str(exc))
-            return result
-
-        pages: List[PageResult] = []
-        for page_num, stream in self._get_page_streams(xref):
-            try:
-                text = _extract_text_from_stream(stream)
-            except Exception as exc:
-                errors.append("page " + str(page_num) + " error: " + str(exc))
-                text = ""
-            pages.append(PageResult(page_number=page_num, text=text))
-
-        result.pages = pages
-        result.page_count = len(pages)
-        result.errors = errors
-        return result
-
-
-# ---------------------------------------------------------------------------
-# Convenience function
-# ---------------------------------------------------------------------------
-
-def extract_pdf(
-    path: str,
-    output_format: str = "text",
-    output_path: Optional[str] = None,
-    max_pages: int = 0,
-) -> str:
-    """
-    Extract text from a PDF and optionally write to a file.
-
-    Parameters
-    ----------
-    path : str
-        Input PDF path.
-    output_format : str
-        "text", "markdown", or "json".
-    output_path : str, optional
-        If given, write output to this file.
-    max_pages : int
-        Maximum number of pages to extract (0 = all).
-
-    Returns
-    -------
-    str
-        Extracted text in the requested format.
-    """
-    extractor = PDFExtractor(path, max_pages=max_pages)
-    result = extractor.extract()
-    if output_format == "json":
-        out = json.dumps(result.to_dict(), indent=2, ensure_ascii=False)
-    elif output_format == "markdown":
-        out = result.to_markdown()
-    else:
-        out = result.full_text
-    if output_path:
-        Path(output_path).write_text(out, encoding="utf-8")
-    return out
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
 
 def _cli() -> None:
-    import argparse
+    import argparse, json as _json
+
     parser = argparse.ArgumentParser(
         prog="pdfextract",
         description="Extract structured text and metadata from PDF files.",
     )
-    parser.add_argument("input", help="Path to input PDF file.")
-    parser.add_argument("-o", "--output", default=None, help="Output file path.")
+    parser.add_argument("input", nargs="+", help="PDF file(s) to process.")
+    parser.add_argument("-o", "--output", default=None,
+                        help="Output file (single input) or directory (batch).")
     parser.add_argument(
         "-f", "--format",
         choices=["text", "markdown", "json"],
         default="text",
         dest="fmt",
     )
-    parser.add_argument("-p", "--max-pages", type=int, default=0)
+    parser.add_argument("-p", "--max-pages", type=int, default=0,
+                        metavar="N", help="Max pages per file (0 = all).")
     args = parser.parse_args()
-    out = extract_pdf(args.input, output_format=args.fmt,
-                      output_path=args.output, max_pages=args.max_pages)
-    if not args.output:
-        print(out)
+
+    if len(args.input) == 1:
+        out = extract_pdf(
+            args.input[0],
+            output_format=args.fmt,
+            output_path=args.output,
+            max_pages=args.max_pages,
+        )
+        if not args.output:
+            print(out)
+        else:
+            print(f"Written to {args.output}")
     else:
-        print("Written to " + args.output)
+        results = extract_batch(
+            args.input,
+            output_format=args.fmt,
+            output_dir=args.output,
+            max_pages=args.max_pages,
+        )
+        for r in results:
+            status = "ok" if not r.errors else f"{len(r.errors)} error(s)"
+            print(f"{r.source}: {r.page_count} pages, {r.word_count} words [{status}]")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfextract"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pure-Python structured text and metadata extractor for PDF files"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,7 +21,11 @@ classifiers = [
 ]
 
 [project.scripts]
-pdfextract = "pdfextract:_cli"
+pdfextract    = "pdfextract:_cli"
+pdfextract-gui = "pdfextract.gui:main"
 
-[tool.setuptools]
-py-modules = ["pdfextract"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"

--- a/src/pdfextract/__init__.py
+++ b/src/pdfextract/__init__.py
@@ -1,17 +1,34 @@
 """
-pdfextract: Structured scientific PDF content extraction tool.
+pdfextract: Structured extraction of text, tables, and metadata from scientific PDFs.
 
-Parses scientific PDF documents and extracts structured content: sections,
-abstracts, figures, tables, captions, equations, citations, and metadata.
-Output is emitted as structured JSON, enabling downstream text mining,
-dataset construction, and reproducible scientific content analysis pipelines.
+Pure-Python PDF parser (no external binaries) that reads cross-reference tables,
+decodes content streams, resolves page-content references, and outputs plain text,
+Markdown, or JSON. Includes a Tkinter GUI (``pdfextract-gui``) and a CLI
+(``pdfextract``).
+
+Quick start::
+
+    from pdfextract import extract_pdf
+    text = extract_pdf("paper.pdf")
+
+    from pdfextract import PDFExtractor
+    result = PDFExtractor("paper.pdf").extract()
+    print(result.metadata)
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .extractor import PDFExtractor
-from .schema import ExtractionResult
+from ._parser import PDFParseError
+from .extractor import PDFExtractor, extract_pdf, extract_batch
+from .schema import ExtractionResult, PageResult
 
-__all__ = ["PDFExtractor", "ExtractionResult"]
+__all__ = [
+    "PDFExtractor",
+    "ExtractionResult",
+    "PageResult",
+    "PDFParseError",
+    "extract_pdf",
+    "extract_batch",
+]

--- a/src/pdfextract/_parser.py
+++ b/src/pdfextract/_parser.py
@@ -1,0 +1,304 @@
+"""Low-level pure-Python PDF parser (PDF 1.x, no encryption)."""
+from __future__ import annotations
+import re
+import zlib
+from typing import Dict, List, Optional, Tuple
+
+
+class PDFParseError(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference and trailer
+# ---------------------------------------------------------------------------
+
+def find_xref_offset(data: bytes) -> int:
+    tail = data[-1024:]
+    m = re.search(rb"startxref\s+(\d+)", tail)
+    if not m:
+        raise PDFParseError("startxref not found")
+    return int(m.group(1))
+
+
+def parse_xref_and_trailer(data: bytes, offset: int) -> Tuple[Dict[int, int], Dict]:
+    """Parse classic xref table plus trailer dict. Returns (offsets, trailer)."""
+    offsets: Dict[int, int] = {}
+    chunk = data[offset:offset + 131072]
+    text = chunk.decode("latin-1", errors="replace")
+    lines = text.splitlines()
+    i = 0
+    if lines and lines[i].strip() == "xref":
+        i += 1
+    while i < len(lines):
+        m = re.match(r"(\d+)\s+(\d+)", lines[i].strip())
+        if not m:
+            break
+        first_obj, count = int(m.group(1)), int(m.group(2))
+        i += 1
+        for j in range(count):
+            if i >= len(lines):
+                break
+            parts = lines[i].strip().split()
+            i += 1
+            if len(parts) >= 3 and parts[2] == "n":
+                offsets[first_obj + j] = int(parts[0])
+
+    trailer: Dict = {}
+    trailer_m = re.search(rb"trailer\s*<<(.+?)>>", chunk, re.DOTALL)
+    if trailer_m:
+        trailer = _parse_dict_refs(trailer_m.group(1))
+    return offsets, trailer
+
+
+def _parse_dict_refs(raw: bytes) -> Dict:
+    """Extract key→(obj_id, gen) or key→int from a flat PDF dict bytes."""
+    result: Dict = {}
+    for m in re.finditer(
+        rb"/(\w+)\s+(?:(\d+)\s+(\d+)\s+R|(\d+))",
+        raw,
+    ):
+        key = m.group(1).decode("latin-1")
+        if m.group(2) is not None:
+            result[key] = ("ref", int(m.group(2)))
+        elif m.group(4) is not None:
+            result[key] = int(m.group(4))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Object access
+# ---------------------------------------------------------------------------
+
+def get_obj_body(data: bytes, byte_off: int) -> Tuple[int, bytes]:
+    chunk = data[byte_off:byte_off + 131072]
+    m = re.search(rb"(\d+)\s+\d+\s+obj", chunk)
+    if not m:
+        raise PDFParseError(f"obj marker not found at offset {byte_off}")
+    start = m.end()
+    end_m = re.search(rb"\bendobj\b", chunk[start:])
+    body = chunk[start: start + end_m.start()] if end_m else chunk[start:]
+    return int(m.group(1)), body
+
+
+def _decode_flate(raw: bytes) -> bytes:
+    for wbits in (15, -15):
+        try:
+            return zlib.decompress(raw, wbits)
+        except zlib.error:
+            pass
+    return raw
+
+
+def extract_stream(obj_body: bytes) -> Optional[bytes]:
+    m = re.search(rb"stream\r?\n", obj_body)
+    if not m:
+        return None
+    start = m.end()
+    end_m = re.search(rb"endstream", obj_body[start:])
+    raw = obj_body[start: start + end_m.start()] if end_m else obj_body[start:]
+    if b"FlateDecode" in obj_body[:start]:
+        raw = _decode_flate(raw)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Page tree traversal
+# ---------------------------------------------------------------------------
+
+def _resolve_ref(trailer_or_dict: Dict, key: str) -> Optional[int]:
+    v = trailer_or_dict.get(key)
+    if isinstance(v, tuple) and v[0] == "ref":
+        return v[1]
+    return None
+
+
+def _walk_page_tree(
+    data: bytes,
+    xref: Dict[int, int],
+    node_id: int,
+    out: List[bytes],
+    depth: int = 0,
+) -> None:
+    if depth > 64 or node_id not in xref:
+        return
+    try:
+        _, body = get_obj_body(data, xref[node_id])
+    except PDFParseError:
+        return
+
+    is_pages = b"/Type /Pages" in body or b"/Type\n/Pages" in body
+    if is_pages:
+        kids_m = re.search(rb"/Kids\s*\[([^\]]+)\]", body)
+        if kids_m:
+            for kid_id in re.findall(rb"(\d+)\s+\d+\s+R", kids_m.group(1)):
+                _walk_page_tree(data, xref, int(kid_id), out, depth + 1)
+    else:
+        # Treat any non-Pages node as a Page
+        out.append(body)
+
+
+def get_page_bodies(
+    data: bytes,
+    xref: Dict[int, int],
+    trailer: Dict,
+) -> List[bytes]:
+    """Return ordered list of Page object bodies by walking the page tree."""
+    root_id = _resolve_ref(trailer, "Root")
+    if root_id is None or root_id not in xref:
+        return _fallback_page_bodies(data, xref)
+
+    try:
+        _, catalog = get_obj_body(data, xref[root_id])
+    except PDFParseError:
+        return _fallback_page_bodies(data, xref)
+
+    pages_m = re.search(rb"/Pages\s+(\d+)\s+\d+\s+R", catalog)
+    if not pages_m:
+        return _fallback_page_bodies(data, xref)
+
+    pages_root = int(pages_m.group(1))
+    out: List[bytes] = []
+    _walk_page_tree(data, xref, pages_root, out)
+    return out if out else _fallback_page_bodies(data, xref)
+
+
+def _fallback_page_bodies(data: bytes, xref: Dict[int, int]) -> List[bytes]:
+    """Scan all objects for /Type /Page as a last-resort fallback."""
+    pages = []
+    for obj_id in sorted(xref.keys()):
+        try:
+            _, body = get_obj_body(data, xref[obj_id])
+        except PDFParseError:
+            continue
+        if b"/Type /Page" in body or b"/Type\n/Page" in body:
+            pages.append(body)
+    return pages
+
+
+def get_content_stream(
+    data: bytes,
+    xref: Dict[int, int],
+    page_body: bytes,
+) -> Optional[bytes]:
+    """Resolve /Contents reference(s) and return the combined content stream."""
+    # Single reference: /Contents 5 0 R
+    single = re.search(rb"/Contents\s+(\d+)\s+\d+\s+R", page_body)
+    if single:
+        cid = int(single.group(1))
+        if cid in xref:
+            try:
+                _, cbody = get_obj_body(data, xref[cid])
+                return extract_stream(cbody)
+            except PDFParseError:
+                pass
+
+    # Array: /Contents [5 0 R 6 0 R ...]
+    arr = re.search(rb"/Contents\s*\[([^\]]+)\]", page_body)
+    if arr:
+        parts = []
+        for cid in re.findall(rb"(\d+)\s+\d+\s+R", arr.group(1)):
+            cid = int(cid)
+            if cid in xref:
+                try:
+                    _, cbody = get_obj_body(data, xref[cid])
+                    s = extract_stream(cbody)
+                    if s:
+                        parts.append(s)
+                except PDFParseError:
+                    pass
+        if parts:
+            return b" ".join(parts)
+
+    # Inline stream on the page object itself (rare)
+    return extract_stream(page_body)
+
+
+# ---------------------------------------------------------------------------
+# Metadata from /Info dictionary
+# ---------------------------------------------------------------------------
+
+_INFO_KEYS = ("Title", "Author", "Subject", "Keywords", "Creator", "Producer")
+
+
+def get_metadata(data: bytes, xref: Dict[int, int], trailer: Dict) -> Dict[str, str]:
+    info_id = _resolve_ref(trailer, "Info")
+    if info_id is None or info_id not in xref:
+        return {}
+    try:
+        _, body = get_obj_body(data, xref[info_id])
+    except PDFParseError:
+        return {}
+
+    meta: Dict[str, str] = {}
+    for key in _INFO_KEYS:
+        m = re.search(rb"/" + key.encode() + rb"\s*\(([^)]*(?:\\.[^)]*)*)\)", body)
+        if m:
+            meta[key] = _decode_pdf_string(m.group(1))
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Text extraction from content streams
+# ---------------------------------------------------------------------------
+
+_BT_ET = re.compile(rb"BT(.+?)ET", re.DOTALL)
+_STRING_RE = re.compile(rb"\(([^)\\]|\\.)*\)")
+_TJ_ARRAY = re.compile(rb"\[([^\]]+)\]\s*TJ")
+
+
+def extract_text_from_stream(stream: bytes) -> str:
+    """Extract text from a PDF content stream, avoiding duplicate extraction."""
+    parts: List[str] = []
+    for bt in _BT_ET.finditer(stream):
+        block = bt.group(1)
+        # Track positions covered by TJ arrays so we don't double-extract
+        tj_spans = set()
+        for tj in _TJ_ARRAY.finditer(block):
+            inner = tj.group(1)
+            for s in _STRING_RE.finditer(inner):
+                parts.append(_decode_pdf_string(s.group(0)[1:-1]))
+            tj_spans.add((tj.start(), tj.end()))
+
+        # Extract remaining Tj / TD strings not inside TJ arrays
+        for s in _STRING_RE.finditer(block):
+            # Skip strings already consumed by TJ array processing
+            pos = s.start()
+            in_tj = any(a <= pos < b for a, b in tj_spans)
+            if not in_tj:
+                parts.append(_decode_pdf_string(s.group(0)[1:-1]))
+
+    return " ".join(p.strip() for p in parts if p.strip())
+
+
+def _decode_pdf_string(s: bytes) -> str:
+    out: List[str] = []
+    i = 0
+    while i < len(s):
+        c = s[i:i + 1]
+        if c == b"\\":
+            i += 1
+            if i >= len(s):
+                break
+            nc = s[i:i + 1]
+            if nc == b"n":
+                out.append("\n")
+            elif nc == b"r":
+                out.append("\r")
+            elif nc == b"t":
+                out.append("\t")
+            elif nc in (b"(", b")"):
+                out.append(nc.decode("latin-1"))
+            elif nc.isdigit():
+                octal = s[i:i + 3]
+                try:
+                    out.append(chr(int(octal, 8)))
+                except ValueError:
+                    out.append(nc.decode("latin-1", errors="replace"))
+                i += 2  # outer loop adds 1 more → 3 total
+            else:
+                out.append(nc.decode("latin-1", errors="replace"))
+        else:
+            out.append(c.decode("latin-1", errors="replace"))
+        i += 1
+    return "".join(out)

--- a/src/pdfextract/extractor.py
+++ b/src/pdfextract/extractor.py
@@ -1,0 +1,157 @@
+"""PDFExtractor: high-level extraction using the low-level parser."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import List, Optional
+
+from ._parser import (
+    PDFParseError,
+    find_xref_offset,
+    parse_xref_and_trailer,
+    get_page_bodies,
+    get_content_stream,
+    get_metadata,
+    extract_text_from_stream,
+)
+from .schema import ExtractionResult, PageResult
+
+
+class PDFExtractor:
+    """
+    Extract text and metadata from a PDF file.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the PDF file.
+    max_pages : int
+        Stop after this many pages (0 = all pages).
+    """
+
+    def __init__(self, path: str, max_pages: int = 0) -> None:
+        self.path = Path(path)
+        self.max_pages = max_pages
+        self._data: bytes = b""
+
+    def _load(self) -> None:
+        self._data = self.path.read_bytes()
+        if self._data[:4] != b"%PDF":
+            raise PDFParseError(f"Not a PDF file: {self.path}")
+
+    def extract(self) -> ExtractionResult:
+        """Run extraction and return an ExtractionResult."""
+        self._load()
+        result = ExtractionResult(source=self.path.name, page_count=0)
+
+        try:
+            offset = find_xref_offset(self._data)
+            xref, trailer = parse_xref_and_trailer(self._data, offset)
+        except PDFParseError as exc:
+            result.errors.append(f"xref error: {exc}")
+            return result
+
+        result.metadata = get_metadata(self._data, xref, trailer)
+
+        page_bodies = get_page_bodies(self._data, xref, trailer)
+        if self.max_pages:
+            page_bodies = page_bodies[: self.max_pages]
+
+        pages: List[PageResult] = []
+        errors: List[str] = []
+        for i, page_body in enumerate(page_bodies, 1):
+            try:
+                stream = get_content_stream(self._data, xref, page_body)
+                text = extract_text_from_stream(stream) if stream else ""
+            except Exception as exc:
+                errors.append(f"page {i} error: {exc}")
+                text = ""
+            pages.append(PageResult(page_number=i, text=text))
+
+        result.pages = pages
+        result.page_count = len(pages)
+        result.errors = errors
+        return result
+
+
+def extract_pdf(
+    path: str,
+    output_format: str = "text",
+    output_path: Optional[str] = None,
+    max_pages: int = 0,
+) -> str:
+    """
+    Extract text from a PDF and optionally write to a file.
+
+    Parameters
+    ----------
+    path : str
+        Input PDF path.
+    output_format : str
+        ``"text"``, ``"markdown"``, or ``"json"``.
+    output_path : str, optional
+        Write output to this path instead of returning.
+    max_pages : int
+        Maximum pages to extract (0 = all).
+
+    Returns
+    -------
+    str
+        Extracted content in the requested format.
+    """
+    result = PDFExtractor(path, max_pages=max_pages).extract()
+    if output_format == "json":
+        out = result.to_json()
+    elif output_format == "markdown":
+        out = result.to_markdown()
+    else:
+        out = result.full_text
+    if output_path:
+        Path(output_path).write_text(out, encoding="utf-8")
+    return out
+
+
+def extract_batch(
+    paths: List[str],
+    output_format: str = "text",
+    output_dir: Optional[str] = None,
+    max_pages: int = 0,
+) -> List[ExtractionResult]:
+    """
+    Extract text from multiple PDFs.
+
+    Parameters
+    ----------
+    paths : list of str
+        Input PDF paths.
+    output_format : str
+        ``"text"``, ``"markdown"``, or ``"json"``.
+    output_dir : str, optional
+        Directory to write output files; filenames mirror input stems.
+    max_pages : int
+        Maximum pages per PDF (0 = all).
+
+    Returns
+    -------
+    list of ExtractionResult
+    """
+    out_dir = Path(output_dir) if output_dir else None
+    if out_dir:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for path in paths:
+        result = PDFExtractor(path, max_pages=max_pages).extract()
+        results.append(result)
+        if out_dir:
+            stem = Path(path).stem
+            ext = {"text": ".txt", "markdown": ".md", "json": ".json"}.get(
+                output_format, ".txt"
+            )
+            if output_format == "json":
+                content = result.to_json()
+            elif output_format == "markdown":
+                content = result.to_markdown()
+            else:
+                content = result.full_text
+            (out_dir / (stem + ext)).write_text(content, encoding="utf-8")
+    return results

--- a/src/pdfextract/gui.py
+++ b/src/pdfextract/gui.py
@@ -1,0 +1,185 @@
+"""Tkinter GUI for pdfextract."""
+from __future__ import annotations
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+from .extractor import PDFExtractor
+
+
+class PDFExtractApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("pdfextract")
+        self.resizable(True, True)
+        self.minsize(680, 520)
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(2, weight=1)
+
+        # ── File row ──────────────────────────────────────────────────
+        file_frame = ttk.LabelFrame(self, text="Input PDF", padding=6)
+        file_frame.grid(row=0, column=0, sticky="ew", padx=8, pady=(8, 4))
+        file_frame.columnconfigure(0, weight=1)
+
+        self._file_var = tk.StringVar()
+        ttk.Entry(file_frame, textvariable=self._file_var).grid(
+            row=0, column=0, sticky="ew", padx=(0, 4)
+        )
+        ttk.Button(file_frame, text="Browse…", command=self._browse).grid(
+            row=0, column=1
+        )
+
+        # ── Options row ───────────────────────────────────────────────
+        opt_frame = ttk.LabelFrame(self, text="Options", padding=6)
+        opt_frame.grid(row=1, column=0, sticky="ew", padx=8, pady=4)
+
+        ttk.Label(opt_frame, text="Output format:").grid(row=0, column=0, sticky="w")
+        self._fmt_var = tk.StringVar(value="text")
+        fmt_cb = ttk.Combobox(
+            opt_frame,
+            textvariable=self._fmt_var,
+            values=["text", "markdown", "json"],
+            state="readonly",
+            width=10,
+        )
+        fmt_cb.grid(row=0, column=1, padx=(4, 20), sticky="w")
+
+        ttk.Label(opt_frame, text="Max pages (0 = all):").grid(
+            row=0, column=2, sticky="w"
+        )
+        self._maxpages_var = tk.StringVar(value="0")
+        ttk.Spinbox(
+            opt_frame,
+            textvariable=self._maxpages_var,
+            from_=0,
+            to=9999,
+            width=6,
+        ).grid(row=0, column=3, padx=(4, 20), sticky="w")
+
+        self._extract_btn = ttk.Button(
+            opt_frame, text="Extract", command=self._start_extraction
+        )
+        self._extract_btn.grid(row=0, column=4, padx=(0, 4))
+
+        ttk.Button(opt_frame, text="Save…", command=self._save).grid(
+            row=0, column=5
+        )
+
+        # ── Output area ───────────────────────────────────────────────
+        out_frame = ttk.LabelFrame(self, text="Output", padding=6)
+        out_frame.grid(row=2, column=0, sticky="nsew", padx=8, pady=4)
+        out_frame.columnconfigure(0, weight=1)
+        out_frame.rowconfigure(0, weight=1)
+
+        self._output = scrolledtext.ScrolledText(
+            out_frame, wrap=tk.WORD, font=("Courier", 10)
+        )
+        self._output.grid(row=0, column=0, sticky="nsew")
+
+        # ── Status bar ────────────────────────────────────────────────
+        self._status_var = tk.StringVar(value="Ready.")
+        ttk.Label(self, textvariable=self._status_var, anchor="w").grid(
+            row=3, column=0, sticky="ew", padx=8, pady=(2, 6)
+        )
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select PDF",
+            filetypes=[("PDF files", "*.pdf"), ("All files", "*.*")],
+        )
+        if path:
+            self._file_var.set(path)
+
+    def _start_extraction(self) -> None:
+        path = self._file_var.get().strip()
+        if not path:
+            messagebox.showwarning("No file", "Please select a PDF file first.")
+            return
+        if not Path(path).is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+        try:
+            max_pages = int(self._maxpages_var.get())
+        except ValueError:
+            messagebox.showerror("Invalid input", "Max pages must be an integer.")
+            return
+
+        self._extract_btn.state(["disabled"])
+        self._status_var.set("Extracting…")
+        self._output.delete("1.0", tk.END)
+
+        threading.Thread(
+            target=self._run_extraction,
+            args=(path, self._fmt_var.get(), max_pages),
+            daemon=True,
+        ).start()
+
+    def _run_extraction(self, path: str, fmt: str, max_pages: int) -> None:
+        try:
+            result = PDFExtractor(path, max_pages=max_pages).extract()
+            if fmt == "json":
+                text = result.to_json()
+            elif fmt == "markdown":
+                text = result.to_markdown()
+            else:
+                text = result.full_text
+
+            errors = result.errors
+            pages = result.page_count
+            words = result.word_count
+        except Exception as exc:
+            self.after(0, self._extraction_error, str(exc))
+            return
+
+        self.after(0, self._extraction_done, text, pages, words, errors)
+
+    def _extraction_done(
+        self, text: str, pages: int, words: int, errors: list
+    ) -> None:
+        self._output.insert(tk.END, text)
+        msg = f"Done. {pages} page(s), {words} word(s)."
+        if errors:
+            msg += f"  {len(errors)} error(s): {errors[0]}"
+        self._status_var.set(msg)
+        self._extract_btn.state(["!disabled"])
+
+    def _extraction_error(self, msg: str) -> None:
+        messagebox.showerror("Extraction failed", msg)
+        self._status_var.set("Error.")
+        self._extract_btn.state(["!disabled"])
+
+    def _save(self) -> None:
+        content = self._output.get("1.0", tk.END).strip()
+        if not content:
+            messagebox.showinfo("Nothing to save", "Extract a PDF first.")
+            return
+        fmt = self._fmt_var.get()
+        ext = {"markdown": ".md", "json": ".json"}.get(fmt, ".txt")
+        path = filedialog.asksaveasfilename(
+            defaultextension=ext,
+            filetypes=[("Text", "*.txt"), ("Markdown", "*.md"), ("JSON", "*.json")],
+        )
+        if path:
+            Path(path).write_text(content, encoding="utf-8")
+            self._status_var.set(f"Saved to {path}")
+
+
+def main() -> None:
+    app = PDFExtractApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdfextract/schema.py
+++ b/src/pdfextract/schema.py
@@ -1,0 +1,66 @@
+"""Data model for PDF extraction results."""
+from __future__ import annotations
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class PageResult:
+    page_number: int  # 1-based
+    text: str
+    word_count: int = field(init=False)
+    char_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.word_count = len(self.text.split())
+        self.char_count = len(self.text)
+
+
+@dataclass
+class ExtractionResult:
+    source: str
+    page_count: int
+    pages: List[PageResult] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def full_text(self) -> str:
+        return "\n\n".join(p.text for p in self.pages if p.text.strip())
+
+    @property
+    def word_count(self) -> int:
+        return sum(p.word_count for p in self.pages)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source": self.source,
+            "page_count": self.page_count,
+            "word_count": self.word_count,
+            "metadata": self.metadata,
+            "errors": self.errors,
+            "pages": [
+                {"page": p.page_number, "text": p.text, "words": p.word_count}
+                for p in self.pages
+            ],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, ensure_ascii=False)
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Extracted Text: {self.source}",
+            "",
+            f"**Pages**: {self.page_count} | **Words**: {self.word_count}",
+            "",
+        ]
+        if self.metadata:
+            lines += ["## Metadata", ""]
+            for k, v in self.metadata.items():
+                lines.append(f"- **{k}**: {v}")
+            lines.append("")
+        for page in self.pages:
+            lines += [f"## Page {page.page_number}", "", page.text, ""]
+        return "\n".join(lines)

--- a/tests/test_pdfextract.py
+++ b/tests/test_pdfextract.py
@@ -1,18 +1,285 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""Tests for pdfextract."""
+from __future__ import annotations
+import io
+import sys
+import zlib
+from pathlib import Path
 
-def test_import():
-    import pdfextract
-    assert hasattr(pdfextract, 'extract_pdf')
+import pytest
 
-def test_pdf_parse_error():
-    import pdfextract
-    assert hasattr(pdfextract, 'PDFParseError')
+# Ensure src/ is on the path for editable installs and direct runs
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-def test_page_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'PageResult')
+import pdfextract
+from pdfextract import PDFExtractor, ExtractionResult, PageResult, PDFParseError, extract_pdf
+from pdfextract._parser import (
+    _decode_pdf_string,
+    extract_text_from_stream,
+    parse_xref_and_trailer,
+    find_xref_offset,
+)
 
-def test_extraction_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'ExtractionResult')
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+class TestPublicAPI:
+    def test_has_extract_pdf(self):
+        assert callable(pdfextract.extract_pdf)
+
+    def test_has_extract_batch(self):
+        assert callable(pdfextract.extract_batch)
+
+    def test_has_pdf_parse_error(self):
+        assert issubclass(pdfextract.PDFParseError, Exception)
+
+    def test_has_page_result(self):
+        assert pdfextract.PageResult is not None
+
+    def test_has_extraction_result(self):
+        assert pdfextract.ExtractionResult is not None
+
+    def test_version(self):
+        assert hasattr(pdfextract, "__version__")
+        assert pdfextract.__version__
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+class TestPageResult:
+    def test_word_and_char_counts(self):
+        pr = PageResult(page_number=1, text="hello world foo")
+        assert pr.word_count == 3
+        assert pr.char_count == 15
+
+    def test_empty_text(self):
+        pr = PageResult(page_number=1, text="")
+        assert pr.word_count == 0
+        assert pr.char_count == 0
+
+
+class TestExtractionResult:
+    def _make(self) -> ExtractionResult:
+        pages = [
+            PageResult(page_number=1, text="Hello world"),
+            PageResult(page_number=2, text="foo bar baz"),
+        ]
+        return ExtractionResult(
+            source="test.pdf",
+            page_count=2,
+            pages=pages,
+            metadata={"Title": "Test"},
+            errors=[],
+        )
+
+    def test_full_text(self):
+        r = self._make()
+        assert "Hello world" in r.full_text
+        assert "foo bar baz" in r.full_text
+
+    def test_word_count(self):
+        r = self._make()
+        assert r.word_count == 5
+
+    def test_to_dict_keys(self):
+        d = self._make().to_dict()
+        for key in ("source", "page_count", "word_count", "metadata", "errors", "pages"):
+            assert key in d
+
+    def test_to_json_valid(self):
+        import json
+        d = json.loads(self._make().to_json())
+        assert d["source"] == "test.pdf"
+
+    def test_to_markdown_contains_header(self):
+        md = self._make().to_markdown()
+        assert "# Extracted Text" in md
+        assert "## Page 1" in md
+        assert "Title" in md
+
+
+# ---------------------------------------------------------------------------
+# PDF string decoder
+# ---------------------------------------------------------------------------
+
+class TestDecodePDFString:
+    def test_plain_ascii(self):
+        assert _decode_pdf_string(b"hello") == "hello"
+
+    def test_escape_n(self):
+        assert _decode_pdf_string(b"a\\nb") == "a\nb"
+
+    def test_escape_t(self):
+        assert _decode_pdf_string(b"a\\tb") == "a\tb"
+
+    def test_escape_parens(self):
+        assert _decode_pdf_string(b"\\(hi\\)") == "(hi)"
+
+    def test_octal(self):
+        # \101 = 'A'
+        assert _decode_pdf_string(b"\\101") == "A"
+
+    def test_empty(self):
+        assert _decode_pdf_string(b"") == ""
+
+
+# ---------------------------------------------------------------------------
+# Text stream extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractTextFromStream:
+    def test_simple_tj(self):
+        stream = b"BT (Hello World) Tj ET"
+        assert "Hello World" in extract_text_from_stream(stream)
+
+    def test_tj_array(self):
+        stream = b"BT [(foo) 10 (bar)] TJ ET"
+        result = extract_text_from_stream(stream)
+        assert "foo" in result
+        assert "bar" in result
+
+    def test_no_duplicate_from_tj_array(self):
+        stream = b"BT [(word)] TJ ET"
+        result = extract_text_from_stream(stream)
+        # "word" should appear exactly once
+        assert result.count("word") == 1
+
+    def test_multiple_bt_et(self):
+        stream = b"BT (alpha) Tj ET BT (beta) Tj ET"
+        result = extract_text_from_stream(stream)
+        assert "alpha" in result
+        assert "beta" in result
+
+    def test_empty_stream(self):
+        assert extract_text_from_stream(b"") == ""
+
+    def test_no_bt_et(self):
+        assert extract_text_from_stream(b"(ignored outside BT/ET)") == ""
+
+
+# ---------------------------------------------------------------------------
+# PDFExtractor with a minimal synthetic PDF
+# ---------------------------------------------------------------------------
+
+def _make_minimal_pdf(page_text: str = "Hello PDF") -> bytes:
+    """Build the smallest valid PDF that pdfextract can parse."""
+    # Compress the content stream
+    content = f"BT ({page_text}) Tj ET".encode()
+    compressed = zlib.compress(content)
+    c_len = len(compressed)
+
+    objects: list[bytes] = []
+
+    # 1 0 obj  Catalog
+    objects.append(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n")
+    # 2 0 obj  Pages
+    objects.append(b"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n")
+    # 3 0 obj  Page (references content stream 4 0 R)
+    objects.append(b"3 0 obj\n<</Type /Page /Parent 2 0 R /Contents 4 0 R>>\nendobj\n")
+    # 4 0 obj  Content stream
+    obj4_header = f"4 0 obj\n<</Length {c_len} /Filter /FlateDecode>>\nstream\n".encode()
+    obj4 = obj4_header + compressed + b"\nendstream\nendobj\n"
+    objects.append(obj4)
+    # 5 0 obj  Info
+    objects.append(b"5 0 obj\n<</Title (Test Document) /Author (Unit Test)>>\nendobj\n")
+
+    body = b"%PDF-1.4\n"
+    offsets: list[int] = []
+    for obj in objects:
+        offsets.append(len(body))
+        body += obj
+
+    xref_offset = len(body)
+    xref = b"xref\n0 6\n0000000000 65535 f \n"
+    for off in offsets:
+        xref += f"{off:010d} 00000 n \n".encode()
+
+    trailer = (
+        b"trailer\n<</Size 6 /Root 1 0 R /Info 5 0 R>>\n"
+        b"startxref\n" + str(xref_offset).encode() + b"\n%%EOF\n"
+    )
+    return body + xref + trailer
+
+
+class TestPDFExtractorSynthetic:
+    def setup_method(self):
+        self._pdf_bytes = _make_minimal_pdf("Hello PDF")
+
+    def _write_tmp(self, tmp_path: Path) -> Path:
+        p = tmp_path / "test.pdf"
+        p.write_bytes(self._pdf_bytes)
+        return p
+
+    def test_basic_extraction(self, tmp_path):
+        p = self._write_tmp(tmp_path)
+        result = PDFExtractor(str(p)).extract()
+        assert result.page_count == 1
+        assert not result.errors
+
+    def test_metadata_extracted(self, tmp_path):
+        p = self._write_tmp(tmp_path)
+        result = PDFExtractor(str(p)).extract()
+        assert result.metadata.get("Title") == "Test Document"
+        assert result.metadata.get("Author") == "Unit Test"
+
+    def test_max_pages_respected(self, tmp_path):
+        p = self._write_tmp(tmp_path)
+        result = PDFExtractor(str(p), max_pages=0).extract()
+        assert result.page_count >= 1
+
+    def test_not_a_pdf_raises(self, tmp_path):
+        bad = tmp_path / "bad.pdf"
+        bad.write_bytes(b"not a pdf file")
+        with pytest.raises(PDFParseError):
+            PDFExtractor(str(bad)).extract()
+
+    def test_extract_pdf_text(self, tmp_path):
+        p = self._write_tmp(tmp_path)
+        out = extract_pdf(str(p), output_format="text")
+        assert isinstance(out, str)
+
+    def test_extract_pdf_json(self, tmp_path):
+        import json
+        p = self._write_tmp(tmp_path)
+        out = extract_pdf(str(p), output_format="json")
+        d = json.loads(out)
+        assert "pages" in d
+
+    def test_extract_pdf_markdown(self, tmp_path):
+        p = self._write_tmp(tmp_path)
+        out = extract_pdf(str(p), output_format="markdown")
+        assert "# Extracted Text" in out
+
+    def test_extract_pdf_to_file(self, tmp_path):
+        p = self._write_tmp(tmp_path)
+        out_file = tmp_path / "out.txt"
+        extract_pdf(str(p), output_path=str(out_file))
+        assert out_file.exists()
+        assert out_file.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Batch extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractBatch:
+    def test_batch_returns_list(self, tmp_path):
+        pdf = _make_minimal_pdf()
+        p1 = tmp_path / "a.pdf"
+        p2 = tmp_path / "b.pdf"
+        p1.write_bytes(pdf)
+        p2.write_bytes(pdf)
+        results = pdfextract.extract_batch([str(p1), str(p2)])
+        assert len(results) == 2
+        assert all(isinstance(r, ExtractionResult) for r in results)
+
+    def test_batch_writes_output_dir(self, tmp_path):
+        pdf = _make_minimal_pdf()
+        p = tmp_path / "doc.pdf"
+        p.write_bytes(pdf)
+        out_dir = tmp_path / "output"
+        pdfextract.extract_batch([str(p)], output_format="text", output_dir=str(out_dir))
+        assert (out_dir / "doc.txt").exists()


### PR DESCRIPTION
## Summary

- **Critical bug fix — page text was never extracted**: page objects store content via a `/Contents N 0 R` indirect reference; the old code called `_extract_stream()` directly on the page object body (which has no stream), so every page returned empty text. The new `_parser.py` walks the PDF page tree, resolves `/Contents` single refs and arrays, and returns the correct content stream.
- **Duplicate text extraction eliminated**: strings inside `[…] TJ` arrays were extracted by both the generic `_STRING_RE` scan and the dedicated TJ loop, doubling every word. Fixed by recording TJ span positions and skipping those ranges in the Tj pass.
- **Metadata extraction added**: the PDF `/Info` dictionary (Title, Author, Subject, Keywords, Creator, Producer) is now parsed from the trailer and returned in `ExtractionResult.metadata`.
- **Proper `src` package layout**: canonical implementation split into `schema.py`, `_parser.py`, `extractor.py` (fixes the broken `__init__.py` that imported non-existent `.extractor` / `.schema` modules).
- **Tkinter GUI** (`pdfextract-gui` entry point): file browser, format selector, max-pages spinner, threaded extraction, output text area, save dialog, status bar.
- **Batch processing** via `extract_batch()` and multi-file CLI.
- **35 unit tests** (up from 4), including a self-contained synthetic PDF fixture that exercises the full parse → extract → output pipeline.

## Test plan

- [ ] `pytest tests/` passes (35/35)
- [ ] `python -m pdfextract paper.pdf` prints text for a real PDF
- [ ] `pdfextract-gui` opens the desktop window and extracts a PDF
- [ ] Batch mode: `pdfextract a.pdf b.pdf -o out/` writes two `.txt` files
- [ ] JSON and Markdown output formats are valid

https://claude.ai/code/session_01XPC6jLnx5yDxf1sP3u2c8h

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPC6jLnx5yDxf1sP3u2c8h)_