### PR TITLE
refactor: JOSS-level debug/refine + tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editor
+.idea/
+.vscode/
+*.swp
+*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,57 @@
 # Changelog
 
 All notable changes to pdfextract are documented here.
+This project follows [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2024-01-15
+## [0.2.0] - 2026-05-08
 
 ### Added
-- Initial release of PDFExtract
-- Text extraction with reading-order reconstruction for single and multi-column layouts
-- Rule-based table detection with CSV and pandas DataFrame export
-- Figure bounding-box detection and captioned image cropping
-- Heuristic section header and metadata (title, authors, abstract) parsing
-- Batch processing CLI with glob pattern input support
-- Output formats: plain text, JSON (structured), and Markdown
-- Optional pdfplumber and pymupdf backends selectable at runtime
-- Unit tests covering extraction accuracy on sample academic PDFs
-- README with installation, CLI usage, and Python API reference
+- PDF 1.5+ cross-reference stream parsing (`/Type /XRef`) with FlateDecode
+  decompression and `/W` field-width decoding
+- `/Prev` pointer chaining to handle incremental-update PDFs
+- Linear byte-scan fallback for structurally incomplete cross-reference tables
+- Proper page-tree traversal via the document catalog (`/Root` → `/Pages`)
+  rather than heuristic scanning
+- Document metadata extraction from the PDF Info dictionary
+  (Title, Author, Subject, Keywords, Creator, Producer)
+- Tkinter GUI (`pdfextract-gui` entry point) for interactive extraction
+- `pdfextract.gui` module with `launch()` function
+- Structured package layout under `src/pdfextract/` with separate modules:
+  `parser`, `schema`, `extractor`, `cli`, `gui`
+- `ExtractionResult.to_json()` helper method
+- `[tool.pytest.ini_options]` with `pythonpath = ["src"]` for running tests
+  without installing the package
+- 49 unit and integration tests covering the parser, data model, CLI, and a
+  synthetically generated minimal PDF
+
+### Changed
+- `pyproject.toml` updated to use the `src/` package layout
+  (`tool.setuptools.packages.find`)
+- CLI entry point changed from `pdfextract:_cli` to `pdfextract.cli:main`
+- Version bumped to `0.2.0`
+- `pdfextract.py` root file updated with improved single-file standalone
+  implementation (all bug fixes backported)
+
+### Fixed
+- Octal escape decoding in PDF literal strings now correctly handles 1–3 digit
+  sequences instead of always consuming exactly 3 digits
+- `OverflowError` no longer raised for octal values outside the Unicode range
+- `src/pdfextract/__init__.py` now imports from existing modules instead of
+  referencing non-existent submodules
+- Page ordering now follows the document page tree instead of xref object ID
+  order
+- Content stream referenced via an indirect object (most real PDFs) is now
+  correctly resolved
+
+## [0.1.0] - 2026-04-23
+
+### Added
+- Initial release
+- Pure-Python PDF parser: classic cross-reference table parsing, FlateDecode
+  stream decompression, BT/ET text extraction
+- `PDFExtractor` class with `extract()` method
+- `ExtractionResult` and `PageResult` dataclasses
+- `extract_pdf()` convenience function
+- Output formats: plain text, Markdown, JSON
+- Command-line interface (`pdfextract` entry point)
+- MIT licence

--- a/README.md
+++ b/README.md
@@ -1,1 +1,171 @@
 # pdfextract
+
+[![CI](https://github.com/vdeshmukh203/pdfextract/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/pdfextract/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org/)
+
+Pure-Python library and CLI for extracting text and metadata from PDF files —
+**no external binaries, no native dependencies**.
+
+## Features
+
+- Parses PDF cross-reference tables (classic xref and PDF 1.5+ xref streams)
+- Follows `/Prev` chains to reconstruct incremental-update histories
+- Traverses the page tree via the document catalog for correct page ordering
+- Decompresses FlateDecode (zlib/deflate) content streams
+- Extracts text from BT/ET blocks (`Tj` and `TJ` operators)
+- Reads document metadata from the PDF Info dictionary
+  (Title, Author, Subject, Keywords, Creator, Producer)
+- Output formats: plain text, Markdown, JSON
+- Graceful degradation on encrypted or malformed PDFs — returns partial
+  results rather than crashing
+- Interactive GUI (tkinter, standard library)
+- Zero run-time dependencies beyond Python ≥ 3.8
+
+## Installation
+
+```bash
+pip install pdfextract
+```
+
+Or clone and install in editable mode:
+
+```bash
+git clone https://github.com/vdeshmukh203/pdfextract
+cd pdfextract
+pip install -e .
+```
+
+## Quick start
+
+### Command line
+
+```bash
+# Plain text to stdout
+pdfextract paper.pdf
+
+# Markdown to file
+pdfextract paper.pdf -f markdown -o paper.md
+
+# JSON (structured, with metadata)
+pdfextract paper.pdf -f json -o paper.json
+
+# First 10 pages only
+pdfextract paper.pdf -p 10
+```
+
+Full usage:
+
+```
+usage: pdfextract [-h] [-o FILE] [-f FORMAT] [-p N] input
+
+positional arguments:
+  input                 Path to the input PDF file.
+
+options:
+  -o, --output FILE     Write output to FILE instead of stdout.
+  -f, --format FORMAT   text (default), markdown, or json.
+  -p, --max-pages N     Stop after N pages (0 = all pages).
+```
+
+### Graphical interface
+
+```bash
+pdfextract-gui
+```
+
+The GUI lets you browse for a PDF, choose output format and page limit, view
+the extracted text, and save the result to a file.
+
+### Python API
+
+```python
+from pdfextract import PDFExtractor, extract_pdf
+
+# High-level one-liner
+text = extract_pdf("paper.pdf")
+
+# Full result object with per-page data and metadata
+result = PDFExtractor("paper.pdf").extract()
+
+print(f"Pages : {result.page_count}")
+print(f"Words : {result.word_count}")
+print(f"Title : {result.metadata.get('Title', 'n/a')}")
+print(f"Author: {result.metadata.get('Author', 'n/a')}")
+
+for page in result.pages:
+    print(f"--- Page {page.page_number} ({page.word_count} words) ---")
+    print(page.text[:200])
+
+# Save as JSON
+import json
+with open("output.json", "w") as f:
+    json.dump(result.to_dict(), f, indent=2)
+
+# Save as Markdown
+with open("output.md", "w") as f:
+    f.write(result.to_markdown())
+```
+
+### JSON output schema
+
+```json
+{
+  "source": "paper.pdf",
+  "page_count": 12,
+  "word_count": 5432,
+  "metadata": {
+    "Title": "My Paper",
+    "Author": "A. Researcher"
+  },
+  "errors": [],
+  "pages": [
+    { "page": 1, "text": "...", "words": 450 },
+    ...
+  ]
+}
+```
+
+## Running tests
+
+```bash
+pip install pytest
+pytest
+```
+
+## Known limitations
+
+- **Encrypted PDFs**: password-protected files are not supported; extraction
+  returns an empty result with an error entry.
+- **ObjStm (compressed object streams, PDF 1.5+)**: objects packed into
+  compressed object streams are not yet resolved.  Most scientific PDFs
+  produced by LaTeX are unaffected.
+- **CIDFont / Unicode ToUnicode maps**: glyph-to-character mapping is not
+  implemented; text in PDFs that rely on CIDFonts may appear garbled.
+- **Right-to-left and vertical scripts**: not supported.
+- **Scanned PDFs**: image-only PDFs contain no text layer; use an OCR tool
+  (e.g., Tesseract) as a pre-processing step.
+
+## Contributing
+
+Contributions are welcome.  Please open an issue before submitting a pull
+request for significant changes.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+## Citation
+
+If you use `pdfextract` in published research, please cite:
+
+```bibtex
+@article{deshmukh2026pdfextract,
+  title   = {pdfextract: Structured extraction of text and metadata from scientific PDF documents},
+  author  = {Deshmukh, Vaibhav},
+  journal = {Journal of Open Source Software},
+  year    = {2026}
+}
+```
+
+Or use the metadata in [CITATION.cff](CITATION.cff).

--- a/paper.bib
+++ b/paper.bib
@@ -1,18 +1,14 @@
-@misc{nist2015sha,
-  author       = {{National Institute of Standards and Technology}},
-  title        = {{FIPS PUB 180-4: Secure Hash Standard (SHS)}},
-  year         = {2015},
-  howpublished = {\url{https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf}},
-  institution  = {National Institute of Standards and Technology}
-}
-
-@article{gundersen2018state,
-  author  = {Gundersen, Odd Erik and Kjensmo, Sigurd},
-  title   = {State of the Art: Reproducibility in Artificial Intelligence},
-  journal = {Proceedings of the AAAI Conference on Artificial Intelligence},
-  volume  = {32},
-  number  = {1},
-  year    = {2018}
+@article{stodden2016enhancing,
+  author  = {Stodden, Victoria and McNutt, Marcia and Bailey, David H. and
+             Deelman, Ewa and Gil, Yolanda and Hanson, Brooks and
+             Heroux, Michael A. and Ioannidis, John P. A. and Taufer, Michela},
+  title   = {Enhancing Reproducibility for Computational Methods},
+  journal = {Science},
+  volume  = {354},
+  number  = {6317},
+  pages   = {1240--1241},
+  year    = {2016},
+  doi     = {10.1126/science.aah6168}
 }
 
 @article{pineau2021improving,
@@ -27,86 +23,11 @@
   year    = {2021}
 }
 
-@article{stodden2016enhancing,
-  author  = {Stodden, Victoria and McNutt, Marcia and Bailey, David H. and Deelman, Ewa and
-             Gil, Yolanda and Hanson, Brooks and Heroux, Michael A. and Ioannidis, John P. A. and
-             Taufer, Michela},
-  title   = {Enhancing Reproducibility for Computational Methods},
-  journal = {Science},
-  volume  = {354},
-  number  = {6317},
-  pages   = {1240--1241},
-  year    = {2016},
-  doi     = {10.1126/science.aah6168}
-}
-
-@article{gebru2021datasheets,
-  author  = {Gebru, Timnit and Morgenstern, Jamie and Vecchione, Briana and
-             Vaughan, Jennifer Wortman and Wallach, Hanna and Daume, Hal and Crawford, Kate},
-  title   = {Datasheets for Datasets},
-  journal = {Communications of the ACM},
-  volume  = {64},
-  number  = {12},
-  pages   = {86--92},
-  year    = {2021},
-  doi     = {10.1145/3458723}
-}
-
-@article{adadi2018peeking,
-  author  = {Adadi, Amina and Berrada, Mohammed},
-  title   = {Peeking Inside the Black-Box: A Survey on Explainable Artificial Intelligence (XAI)},
-  journal = {IEEE Access},
-  volume  = {6},
-  pages   = {52138--52160},
-  year    = {2018},
-  doi     = {10.1109/ACCESS.2018.2870052}
-}
-
-@article{wei2022chain,
-  author  = {Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and
-             Ichter, Brian and Xia, Fei and Chi, Ed and Le, Quoc and Zhou, Denny},
-  title   = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
-  journal = {Advances in Neural Information Processing Systems},
-  volume  = {35},
-  pages   = {24824--24837},
-  year    = {2022}
-}
-
-@article{kung2023chatgpt,
-  author  = {Kung, Tiffany H. and Cheatham, Morgan and Medenilla, Ariel and Sillos, Czarina and
-             De Leon, Lorie and Elepano, Camille and Madriaga, Maria and Aggabao, Rimel and
-             Diaz-Candido, Gerdine and Maningo, James and Tseng, Victor},
-  title   = {Performance of ChatGPT on USMLE: Potential for AI-Assisted Medical Education
-             Using Large Language Models},
-  journal = {PLOS Digital Health},
-  volume  = {2},
-  number  = {2},
-  pages   = {e0000198},
-  year    = {2023},
-  doi     = {10.1371/journal.pdig.0000198}
-}
-
 @article{gao2023reproducibility,
-  author  = {Gao, Luyu and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and
-             Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and
-             Presser, Shawn and Leahy, Connor},
-  title   = {The Pile: An 800GB Dataset of Diverse Text for Language Modeling},
+  author  = {Gao, Luyu and Biderman, Stella and Black, Sid and Golding, Laurence and
+             Hoppe, Travis and Foster, Charles and Phang, Jason and He, Horace and
+             Thite, Anish and Nabeshima, Noa and Presser, Shawn and Leahy, Connor},
+  title   = {The Pile: An 800{GB} Dataset of Diverse Text for Language Modeling},
   journal = {arXiv preprint arXiv:2101.00027},
-  year    = {2023}
-}
-
-@article{perez2022ignore,
-  author  = {Perez, Fabio and Ribeiro, Ian},
-  title   = {Ignore Previous Prompt: Attack Techniques For Language Models},
-  journal = {arXiv preprint arXiv:2211.09527},
-  year    = {2022}
-}
-
-@article{greshake2023not,
-  author  = {Greshake, Kai and Abdelnabi, Sahar and Mishra, Shailesh and Endres, Christoph and
-             Holz, Thorsten and Fritz, Mario},
-  title   = {Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications
-             with Indirect Prompt Injection},
-  journal = {arXiv preprint arXiv:2302.12173},
   year    = {2023}
 }

--- a/paper.md
+++ b/paper.md
@@ -1,12 +1,12 @@
 ---
-title: 'pdfextract: Structured extraction of text, tables, and figures from scientific PDF documents'
+title: 'pdfextract: Pure-Python text and metadata extraction from PDF documents'
 tags:
   - Python
   - PDF
-  - extraction
-  - NLP
-  - scientific-computing
-  - text-mining
+  - text extraction
+  - metadata
+  - scientific computing
+  - text mining
 authors:
   - name: Vaibhav Deshmukh
     orcid: 0000-0001-6745-7062
@@ -20,14 +20,73 @@ bibliography: paper.bib
 
 # Summary
 
-`pdfextract` is a Python library and command-line tool for structured extraction of content from scientific PDF documents. It combines PDF parsing (via `pdfminer.six`), table detection (via heuristic whitespace analysis and `camelot`), and figure boundary detection (via bounding-box analysis of non-text PDF objects) to produce structured output in JSON or Markdown format. Extracted content includes section-segmented body text, tables as pandas DataFrames, figure captions, and metadata (title, authors, abstract, DOI). `pdfextract` is designed for batch processing of paper corpora in systematic review and meta-analysis pipelines.
+`pdfextract` is a pure-Python library and command-line tool for extracting text
+and metadata from PDF documents without requiring any external binaries or
+native library dependencies.  It implements a subset of the PDF specification
+sufficient for the vast majority of scientific papers: cross-reference table
+parsing (both classic tables and PDF 1.5+ cross-reference streams), page-tree
+traversal via the document catalog, FlateDecode stream decompression, BT/ET
+content-stream text extraction, and document-level metadata retrieval from the
+PDF Info dictionary.  Extracted content is returned as structured Python objects
+and can be serialised to plain text, Markdown, or JSON.  An optional tkinter
+graphical interface is provided for interactive use.
 
 # Statement of Need
 
-Scientific text mining pipelines require reliable extraction of structured content from PDF documents, but existing tools either require commercial licences, lack section-awareness, or produce poorly structured output that requires extensive post-processing [@gao2023reproducibility]. `pdfextract` targets the research workflow of processing hundreds to thousands of papers: it provides a batch mode, consistent JSON output schema, and graceful degradation when content cannot be reliably extracted rather than silently producing malformed output. The structured output integrates directly with downstream NLP tools, enabling reproducible corpus construction for meta-analyses and systematic literature reviews [@stodden2016enhancing; @pineau2021improving].
+Scientific text-mining pipelines require reliable extraction of content from PDF
+documents, but existing solutions involve trade-offs that complicate
+reproducibility.  Tools that wrap native binaries (e.g., poppler, mupdf) impose
+system-level dependencies that vary across platforms and package versions,
+making environment reproducibility harder to guarantee
+[@stodden2016enhancing; @pineau2021improving].  Pure-Python alternatives have
+historically been either incomplete or poorly maintained.
+
+`pdfextract` addresses these concerns with a zero-dependency, pure-Python
+implementation that gracefully degrades on encrypted or non-standard PDFs
+rather than crashing, returning partial results with descriptive error entries.
+The consistent JSON output schema integrates directly with downstream NLP tools
+and dataset construction pipelines, supporting reproducible corpus preparation
+for systematic reviews and meta-analyses [@gao2023reproducibility].
+
+# Implementation
+
+The extraction pipeline proceeds as follows:
+
+1. **Cross-reference parsing.** The file's `startxref` offset is located in the
+   final 2 KB of the file.  Both classic cross-reference tables and PDF 1.5+
+   cross-reference streams (compressed with FlateDecode) are parsed, following
+   `/Prev` pointer chains to handle incremental updates.  A linear byte-scan
+   fallback handles structurally incomplete files.
+
+2. **Page tree traversal.** The document catalog is resolved from the trailer's
+   `/Root` reference.  The page tree is traversed recursively from the `/Pages`
+   node, yielding page objects in document order—a more reliable approach than
+   scanning all objects for `/Type /Page` heuristically.
+
+3. **Content stream extraction.** Each page's `/Contents` entry (a direct
+   object reference or an array of references) is resolved and decompressed.
+   Text is extracted by scanning BT/ET blocks for `Tj` and `TJ` operators, and
+   PDF literal strings are decoded including octal escape sequences.
+
+4. **Metadata extraction.** The Info dictionary (referenced by `/Info` in the
+   trailer) is parsed to retrieve Title, Author, Subject, Keywords, Creator, and
+   Producer fields.
+
+5. **Output serialisation.** Results are returned as typed Python dataclasses
+   (`ExtractionResult`, `PageResult`) and can be serialised to plain text,
+   Markdown, or JSON through built-in methods.
+
+# Known Limitations
+
+`pdfextract` does not support password-protected PDFs, CIDFont ToUnicode glyph
+mapping, objects stored in compressed ObjStm streams (PDF 1.5+ compressed
+object streams), or right-to-left scripts.  Scanned image-only PDFs require a
+separate OCR step.  These limitations are documented in the project README.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for assistance during development and
+manuscript preparation.  All scientific claims and design decisions are the
+author's own.
 
 # References

--- a/pdfextract.py
+++ b/pdfextract.py
@@ -1,84 +1,43 @@
 """
-pdfextract: Extract structured text, tables, and metadata from PDF files.
+pdfextract — standalone single-file edition.
 
-Pure-Python PDF parser (no external binaries required) that reads cross-reference
-tables, decodes content streams, extracts text runs with page/position metadata,
-detects table regions via whitespace analysis, and outputs plain text, Markdown,
-or JSON. Falls back gracefully on encrypted or malformed PDFs.
+Pure-Python PDF parser that reads cross-reference tables (classic and stream),
+decodes FlateDecode content streams, extracts text from BT/ET blocks, reads
+the PDF Info dictionary for metadata, and traverses the page tree in document
+order.  Output formats: plain text, Markdown, or JSON.
+
+This file is a self-contained copy of the library for users who prefer to run
+without installing the package.  The canonical installable version lives in
+``src/pdfextract/``.
+
+Usage (CLI)::
+
+    python pdfextract.py paper.pdf
+    python pdfextract.py paper.pdf -f markdown -o paper.md
+    python pdfextract.py paper.pdf -f json -p 5
 """
 from __future__ import annotations
-import re, struct, zlib, json
+
+import json
+import re
+import zlib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 
 # ---------------------------------------------------------------------------
-# PDF low-level parser (supports PDF 1.x; no encryption)
+# Exceptions
 # ---------------------------------------------------------------------------
 
+
 class PDFParseError(Exception):
-    pass
+    """Raised when a structural error prevents parsing."""
 
 
-def _read_bytes(path: Path) -> bytes:
-    return path.read_bytes()
-
-
-def _find_xref_offset(data: bytes) -> int:
-    """Locate startxref offset from end of file."""
-    tail = data[-1024:]
-    m = re.search(rb"startxref\s+(\d+)", tail)
-    if not m:
-        raise PDFParseError("startxref not found.")
-    return int(m.group(1))
-
-
-def _parse_xref_table(data: bytes, offset: int) -> Dict[int, int]:
-    """Parse a classic xref table. Returns {obj_id: byte_offset}."""
-    offsets: Dict[int, int] = {}
-    pos = offset
-    # skip 'xref'
-    chunk = data[pos:pos + 4096].decode("latin-1", errors="replace")
-    lines = chunk.splitlines()
-    i = 0
-    if lines[i].strip() == "xref":
-        i += 1
-    while i < len(lines):
-        header = lines[i].strip()
-        m = re.match(r"(\d+)\s+(\d+)", header)
-        if not m:
-            break
-        first_obj = int(m.group(1))
-        count = int(m.group(2))
-        i += 1
-        for j in range(count):
-            if i >= len(lines):
-                break
-            entry = lines[i].strip()
-            i += 1
-            parts = entry.split()
-            if len(parts) < 3:
-                continue
-            byte_off, gen, kind = parts[0], parts[1], parts[2]
-            obj_id = first_obj + j
-            if kind == "n":
-                offsets[obj_id] = int(byte_off)
-    return offsets
-
-
-def _parse_obj(data: bytes, byte_off: int) -> Tuple[int, bytes]:
-    """Extract the raw bytes of one indirect object."""
-    chunk = data[byte_off:byte_off + 65536]
-    m = re.search(rb"(\d+)\s+(\d+)\s+obj", chunk)
-    if not m:
-        raise PDFParseError("obj marker not found at offset " + str(byte_off))
-    start = m.end()
-    # find matching endobj
-    end_m = re.search(rb"endobj", chunk[start:])
-    if not end_m:
-        return int(m.group(1)), chunk[start:]
-    return int(m.group(1)), chunk[start:start + end_m.start()]
+# ---------------------------------------------------------------------------
+# Decompression
+# ---------------------------------------------------------------------------
 
 
 def _decode_flate(raw: bytes) -> bytes:
@@ -91,88 +50,277 @@ def _decode_flate(raw: bytes) -> bytes:
             return raw
 
 
-def _extract_stream(obj_bytes: bytes) -> Optional[bytes]:
-    """Extract and decompress a PDF stream from an object body."""
-    m = re.search(rb"stream\r?\n", obj_bytes)
+# ---------------------------------------------------------------------------
+# Cross-reference parsing
+# ---------------------------------------------------------------------------
+
+
+def _find_xref_offset(data: bytes) -> int:
+    tail = data[-2048:]
+    m = re.search(rb"startxref\s+(\d+)", tail)
     if not m:
+        raise PDFParseError("startxref not found in file")
+    return int(m.group(1))
+
+
+def _parse_xref_table(
+    data: bytes, offset: int
+) -> Tuple[Dict[int, int], Optional[int]]:
+    offsets: Dict[int, int] = {}
+    chunk = data[offset : offset + max(131072, len(data) - offset)]
+    text = chunk.decode("latin-1", errors="replace")
+    lines = text.splitlines()
+    i = 0
+    if i < len(lines) and lines[i].strip().lower() == "xref":
+        i += 1
+    while i < len(lines):
+        m = re.match(r"^(\d+)\s+(\d+)$", lines[i].strip())
+        if not m:
+            break
+        first_obj, count = int(m.group(1)), int(m.group(2))
+        i += 1
+        for j in range(count):
+            if i >= len(lines):
+                break
+            parts = lines[i].strip().split()
+            i += 1
+            if len(parts) >= 3 and parts[2] == "n":
+                try:
+                    offsets[first_obj + j] = int(parts[0])
+                except ValueError:
+                    pass
+    trailer_text = "\n".join(lines[i : i + 60])
+    prev_m = re.search(r"/Prev\s+(\d+)", trailer_text)
+    return offsets, int(prev_m.group(1)) if prev_m else None
+
+
+def _parse_xref_stream(
+    data: bytes, offset: int
+) -> Tuple[Dict[int, int], Optional[int]]:
+    chunk = data[offset : offset + 131072]
+    stream_m = re.search(rb"stream\r?\n", chunk)
+    if not stream_m:
+        raise PDFParseError("xref stream: 'stream' keyword not found")
+    header = chunk[: stream_m.start()].decode("latin-1", errors="replace")
+    w_m = re.search(r"/W\s*\[\s*([\d\s]+?)\s*\]", header)
+    if not w_m:
+        raise PDFParseError("xref stream: /W entry missing")
+    widths = [int(x) for x in w_m.group(1).split()]
+    if len(widths) != 3:
+        raise PDFParseError(f"xref stream: /W must have 3 entries, got {len(widths)}")
+    entry_size = sum(widths)
+    if entry_size == 0:
+        return {}, None
+    size_m = re.search(r"/Size\s+(\d+)", header)
+    total_size = int(size_m.group(1)) if size_m else 0
+    index_m = re.search(r"/Index\s*\[\s*([\d\s]+?)\s*\]", header)
+    if index_m:
+        idx = [int(x) for x in index_m.group(1).split()]
+        index_pairs = [(idx[k], idx[k + 1]) for k in range(0, len(idx) - 1, 2)]
+    else:
+        index_pairs = [(0, total_size)]
+    prev_m = re.search(r"/Prev\s+(\d+)", header)
+    prev = int(prev_m.group(1)) if prev_m else None
+    body_start = stream_m.end()
+    end_m = re.search(rb"endstream", chunk[body_start:])
+    raw = chunk[
+        body_start : body_start + (
+            end_m.start() if end_m else len(chunk) - body_start
+        )
+    ]
+    if b"FlateDecode" in chunk[: stream_m.start()]:
+        raw = _decode_flate(raw)
+    offsets: Dict[int, int] = {}
+    pos = 0
+    w0, w1 = widths[0], widths[1]
+
+    def _rd(buf: bytes, w: int, default: int = 0) -> int:
+        return default if w == 0 else int.from_bytes(buf[:w], "big")
+
+    for first_obj, count in index_pairs:
+        for j in range(count):
+            if pos + entry_size > len(raw):
+                break
+            entry = raw[pos : pos + entry_size]
+            pos += entry_size
+            ftype = _rd(entry, w0, default=1)
+            f1 = _rd(entry[w0:], w1)
+            if ftype == 1:
+                offsets[first_obj + j] = f1
+    return offsets, prev
+
+
+def _build_xref(data: bytes) -> Dict[int, int]:
+    try:
+        offset: Optional[int] = _find_xref_offset(data)
+    except PDFParseError:
+        return _scan_objects(data)
+    visited: set = set()
+    combined: Dict[int, int] = {}
+    while offset is not None and offset not in visited:
+        visited.add(offset)
+        head = data[offset : offset + 16].lstrip()
+        try:
+            if head.startswith(b"xref"):
+                section, prev = _parse_xref_table(data, offset)
+            else:
+                section, prev = _parse_xref_stream(data, offset)
+        except Exception:
+            break
+        for obj_id, byte_off in section.items():
+            combined.setdefault(obj_id, byte_off)
+        offset = prev  # type: ignore[assignment]
+    return combined or _scan_objects(data)
+
+
+def _scan_objects(data: bytes) -> Dict[int, int]:
+    offsets: Dict[int, int] = {}
+    for m in re.finditer(rb"(?<!\d)(\d+)\s+\d+\s+obj\b", data):
+        obj_id = int(m.group(1))
+        offsets.setdefault(obj_id, m.start())
+    return offsets
+
+
+# ---------------------------------------------------------------------------
+# Object parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_obj(data: bytes, byte_off: int) -> bytes:
+    window = data[byte_off : byte_off + 131072]
+    m = re.search(rb"\d+\s+\d+\s+obj", window)
+    if not m:
+        raise PDFParseError(f"obj marker not found at offset {byte_off}")
+    body_start = m.end()
+    end_m = re.search(rb"endobj", window[body_start:])
+    return window[
+        body_start : body_start + (end_m.start() if end_m else len(window) - body_start)
+    ]
+
+
+def _extract_stream(obj_bytes: bytes) -> Optional[bytes]:
+    sm = re.search(rb"stream\r?\n", obj_bytes)
+    if not sm:
         return None
-    stream_start = m.end()
-    end_m = re.search(rb"endstream", obj_bytes[stream_start:])
-    raw = obj_bytes[stream_start:stream_start + (end_m.start() if end_m else len(obj_bytes))]
-    # Check for FlateDecode
-    if b"FlateDecode" in obj_bytes[:stream_start]:
+    body_start = sm.end()
+    end_m = re.search(rb"endstream", obj_bytes[body_start:])
+    raw = obj_bytes[
+        body_start : body_start + (end_m.start() if end_m else len(obj_bytes))
+    ]
+    if b"FlateDecode" in obj_bytes[: sm.start()]:
         raw = _decode_flate(raw)
     return raw
+
+
+def _resolve(data: bytes, xref: Dict[int, int], ref: str) -> Optional[bytes]:
+    m = re.fullmatch(r"\s*(\d+)\s+\d+\s+R\s*", ref)
+    if not m:
+        return None
+    obj_id = int(m.group(1))
+    if obj_id not in xref:
+        return None
+    try:
+        return _parse_obj(data, xref[obj_id])
+    except PDFParseError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dictionary helpers
+# ---------------------------------------------------------------------------
+
+
+def _dict_get(obj_bytes: bytes, key: str) -> Optional[str]:
+    text = obj_bytes.decode("latin-1", errors="replace")
+    pattern = (
+        r"/" + re.escape(key) + r"\s+"
+        r"(/\w+|<[^>]*>|\[[^\]]*\]|\([^)]*\)|-?\d+(?:\s+\d+\s+R)?|\d+(?:\.\d+)?)"
+    )
+    m = re.search(pattern, text, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def _dict_get_refs(obj_bytes: bytes, key: str) -> List[str]:
+    raw = _dict_get(obj_bytes, key)
+    if raw is None:
+        return []
+    return re.findall(r"\d+\s+\d+\s+R", raw)
 
 
 # ---------------------------------------------------------------------------
 # Text extraction from content streams
 # ---------------------------------------------------------------------------
 
-_TEXT_OPS = re.compile(
-    rb"\(([^)\\]|\\.)*\)\s*Tj"       # (text) Tj
-    rb"|\[([^\]]+)\]\s*TJ"               # [array] TJ
-)
-
-_BT_ET = re.compile(rb"BT(.+?)ET", re.DOTALL)
-_STRING_RE = re.compile(rb"\(([^)\\]|\\.)*\)")
+_BT_ET_RE = re.compile(rb"BT(.+?)ET", re.DOTALL)
+_STR_RE = re.compile(rb"\((?:[^)\\]|\\.)*\)")
 
 
-def _decode_pdf_string(s: bytes) -> str:
-    """Decode a PDF literal string, handling \ooo octal and common escapes."""
-    out = []
+def _decode_pdf_string(raw: bytes) -> str:
+    out: List[str] = []
     i = 0
-    while i < len(s):
-        c = s[i:i+1]
-        if c == b"\\":
+    n = len(raw)
+    while i < n:
+        b = raw[i]
+        if b == ord("\\"):
             i += 1
-            nc = s[i:i+1]
-            if nc in (b"n",):   out.append("\n")
-            elif nc in (b"r",): out.append("\r")
-            elif nc in (b"t",): out.append("\t")
-            elif nc in (b"(",): out.append("(")
-            elif nc in (b")",): out.append(")")
-            elif nc.isdigit():
-                octal = s[i:i+3]
-                out.append(chr(int(octal, 8)))
-                i += 2
+            if i >= n:
+                break
+            esc = raw[i]
+            if esc == ord("n"):
+                out.append("\n"); i += 1
+            elif esc == ord("r"):
+                out.append("\r"); i += 1
+            elif esc == ord("t"):
+                out.append("\t"); i += 1
+            elif esc in (ord("("), ord(")"), ord("\\")):
+                out.append(chr(esc)); i += 1
+            elif ord("0") <= esc <= ord("7"):
+                j, octal = i, ""
+                while j < n and j < i + 3 and ord("0") <= raw[j] <= ord("7"):
+                    octal += chr(raw[j])
+                    j += 1
+                try:
+                    out.append(chr(int(octal, 8)))
+                except (ValueError, OverflowError):
+                    pass
+                i = j
             else:
-                out.append(nc.decode("latin-1", errors="replace"))
+                out.append(chr(esc)); i += 1
         else:
-            out.append(c.decode("latin-1", errors="replace"))
-        i += 1
+            out.append(chr(b) if b < 128 else raw[i : i + 1].decode("latin-1"))
+            i += 1
     return "".join(out)
 
 
 def _extract_text_from_stream(stream: bytes) -> str:
-    """Pull text from a PDF content stream using simple BT/ET block parsing."""
     parts: List[str] = []
-    for bt_block in _BT_ET.finditer(stream):
-        block = bt_block.group(1)
-        for string_m in _STRING_RE.finditer(block):
-            raw = string_m.group(0)[1:-1]  # strip parens
-            parts.append(_decode_pdf_string(raw))
-        # Also catch bare TJ arrays
-        for tj_m in re.finditer(rb"\[([^\]]+)\]\s*TJ", block):
-            inner = tj_m.group(1)
-            for s in _STRING_RE.finditer(inner):
-                raw = s.group(0)[1:-1]
-                parts.append(_decode_pdf_string(raw))
-    return " ".join(p.strip() for p in parts if p.strip())
+    for bt in _BT_ET_RE.finditer(stream):
+        block = bt.group(1)
+        for sm in _STR_RE.finditer(block):
+            text = _decode_pdf_string(sm.group(0)[1:-1])
+            if text.strip():
+                parts.append(text.strip())
+        for tj in re.finditer(rb"\[([^\]]+)\]\s*TJ", block):
+            for sm in _STR_RE.finditer(tj.group(1)):
+                text = _decode_pdf_string(sm.group(0)[1:-1])
+                if text.strip():
+                    parts.append(text.strip())
+    return " ".join(parts)
 
 
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class PageResult:
-    page_number: int          # 1-based
+    page_number: int
     text: str
-    word_count: int = 0
-    char_count: int = 0
+    word_count: int = field(init=False)
+    char_count: int = field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.word_count = len(self.text.split())
         self.char_count = len(self.text)
 
@@ -200,97 +348,175 @@ class ExtractionResult:
             "word_count": self.word_count,
             "metadata": self.metadata,
             "errors": self.errors,
-            "pages": [{"page": p.page_number, "text": p.text,
-                       "words": p.word_count} for p in self.pages],
+            "pages": [
+                {"page": p.page_number, "text": p.text, "words": p.word_count}
+                for p in self.pages
+            ],
         }
 
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
     def to_markdown(self) -> str:
-        lines = [
-            "# Extracted Text: " + self.source, "",
-            "**Pages**: " + str(self.page_count) + " | **Words**: " + str(self.word_count), "",
+        lines: List[str] = [
+            f"# Extracted Text: {self.source}",
+            "",
+            f"**Pages**: {self.page_count} | **Words**: {self.word_count}",
+            "",
         ]
         if self.metadata:
             lines += ["## Metadata", ""]
             for k, v in self.metadata.items():
-                lines.append("- **" + k + "**: " + v)
+                lines.append(f"- **{k}**: {v}")
             lines.append("")
         for page in self.pages:
-            lines += [
-                "## Page " + str(page.page_number), "",
-                page.text, "",
-            ]
+            lines += [f"## Page {page.page_number}", "", page.text, ""]
         return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
-# Main extractor
+# Extractor
 # ---------------------------------------------------------------------------
 
+
 class PDFExtractor:
-    """
-    Extract text and metadata from a PDF file without external binaries.
+    """Extract text and metadata from a PDF without external binaries.
 
     Parameters
     ----------
     path : str
         Path to the PDF file.
     max_pages : int, optional
-        Stop after this many pages. 0 = all pages.
+        Maximum pages to extract (0 = all).
     """
 
     def __init__(self, path: str, max_pages: int = 0) -> None:
         self.path = Path(path)
         self.max_pages = max_pages
         self._data: bytes = b""
+        self._xref: Dict[int, int] = {}
 
     def _load(self) -> None:
-        self._data = _read_bytes(self.path)
-        magic = self._data[:4]
-        if magic != b"%PDF":
-            raise PDFParseError("Not a PDF file: " + str(self.path))
+        self._data = self.path.read_bytes()
+        if self._data[:4] != b"%PDF":
+            raise PDFParseError(f"Not a PDF file: {self.path}")
 
-    def _get_xref(self) -> Dict[int, int]:
-        offset = _find_xref_offset(self._data)
-        return _parse_xref_table(self._data, offset)
+    def _get_obj(self, obj_id: int) -> Optional[bytes]:
+        if obj_id not in self._xref:
+            return None
+        try:
+            return _parse_obj(self._data, self._xref[obj_id])
+        except PDFParseError:
+            return None
 
-    def _get_page_streams(self, xref: Dict[int, int]) -> Iterator[Tuple[int, bytes]]:
-        """Yield (page_index, content_stream_bytes)."""
-        page_num = 0
-        for obj_id in sorted(xref.keys()):
-            byte_off = xref[obj_id]
-            try:
-                _, obj_body = _parse_obj(self._data, byte_off)
-            except PDFParseError:
+    def _resolve_ref(self, ref: str) -> Optional[bytes]:
+        return _resolve(self._data, self._xref, ref)
+
+    def _find_root_ref(self) -> Optional[str]:
+        tail = self._data[-4096:].decode("latin-1", errors="replace")
+        m = re.search(r"/Root\s+(\d+\s+\d+\s+R)", tail)
+        if m:
+            return m.group(1)
+        for obj_id in self._xref:
+            ob = self._get_obj(obj_id)
+            if ob is None:
                 continue
-            # Heuristic: objects containing /Type /Page with /Contents
-            if b"/Type /Page" in obj_body or b"/Type\n/Page" in obj_body:
-                stream = _extract_stream(obj_body)
-                if stream:
-                    page_num += 1
-                    yield page_num, stream
-                    if self.max_pages and page_num >= self.max_pages:
-                        return
+            txt = ob.decode("latin-1", errors="replace")
+            if "/Type" in txt and "/XRef" in txt:
+                m = re.search(r"/Root\s+(\d+\s+\d+\s+R)", txt)
+                if m:
+                    return m.group(1)
+        return None
 
-    def extract(self) -> ExtractionResult:
+    def _extract_metadata(self) -> Dict[str, str]:
+        tail = self._data[-4096:].decode("latin-1", errors="replace")
+        info_m = re.search(r"/Info\s+(\d+\s+\d+\s+R)", tail)
+        if not info_m:
+            return {}
+        info_bytes = self._resolve_ref(info_m.group(1))
+        if info_bytes is None:
+            return {}
+        metadata: Dict[str, str] = {}
+        for key in ("Title", "Author", "Subject", "Keywords", "Creator", "Producer"):
+            raw = _dict_get(info_bytes, key)
+            if raw:
+                if raw.startswith("(") and raw.endswith(")"):
+                    raw = raw[1:-1]
+                metadata[key] = raw.strip()
+        return metadata
+
+    def _iter_pages(self, root_ref: str) -> Iterator[bytes]:
+        catalog = self._resolve_ref(root_ref)
+        if catalog is None:
+            return
+        pages_ref = _dict_get(catalog, "Pages")
+        if pages_ref and re.search(r"\d+\s+\d+\s+R", pages_ref):
+            yield from self._walk_tree(pages_ref)
+
+    def _walk_tree(self, node_ref: str) -> Iterator[bytes]:
+        node = self._resolve_ref(node_ref)
+        if node is None:
+            return
+        if _dict_get(node, "Type") == "/Page":
+            yield node
+        else:
+            for kid_ref in _dict_get_refs(node, "Kids"):
+                yield from self._walk_tree(kid_ref)
+
+    def _fallback_scan(self) -> Iterator[bytes]:
+        for obj_id in sorted(self._xref):
+            ob = self._get_obj(obj_id)
+            if ob is None:
+                continue
+            txt = ob.decode("latin-1", errors="replace")
+            if "/Type" in txt and "/Page" in txt and "/Pages" not in txt:
+                yield ob
+
+    def _page_text(self, page_obj: bytes) -> str:
+        contents = _dict_get(page_obj, "Contents")
+        if contents is None:
+            return ""
+        if contents.startswith("["):
+            refs = re.findall(r"\d+\s+\d+\s+R", contents)
+        elif re.search(r"\d+\s+\d+\s+R", contents):
+            refs = [contents]
+        else:
+            return ""
+        streams: List[bytes] = []
+        for ref in refs:
+            obj = self._resolve_ref(ref)
+            if obj is not None:
+                sd = _extract_stream(obj)
+                if sd:
+                    streams.append(sd)
+        combined = b"\n".join(streams)
+        return _extract_text_from_stream(combined) if combined else ""
+
+    def extract(self) -> "ExtractionResult":
         """Run extraction. Returns ExtractionResult."""
         self._load()
         result = ExtractionResult(source=self.path.name, page_count=0)
         errors: List[str] = []
         try:
-            xref = self._get_xref()
-        except PDFParseError as exc:
-            result.errors.append("xref error: " + str(exc))
+            self._xref = _build_xref(self._data)
+        except Exception as exc:
+            result.errors.append(f"xref error: {exc}")
             return result
-
+        result.metadata = self._extract_metadata()
+        root_ref = self._find_root_ref()
+        page_src = (
+            self._iter_pages(root_ref) if root_ref else self._fallback_scan()
+        )
         pages: List[PageResult] = []
-        for page_num, stream in self._get_page_streams(xref):
+        for page_num, page_obj in enumerate(page_src, start=1):
             try:
-                text = _extract_text_from_stream(stream)
+                text = self._page_text(page_obj)
             except Exception as exc:
-                errors.append("page " + str(page_num) + " error: " + str(exc))
+                errors.append(f"page {page_num}: {exc}")
                 text = ""
             pages.append(PageResult(page_number=page_num, text=text))
-
+            if self.max_pages and page_num >= self.max_pages:
+                break
         result.pages = pages
         result.page_count = len(pages)
         result.errors = errors
@@ -301,35 +527,34 @@ class PDFExtractor:
 # Convenience function
 # ---------------------------------------------------------------------------
 
+
 def extract_pdf(
     path: str,
     output_format: str = "text",
     output_path: Optional[str] = None,
     max_pages: int = 0,
 ) -> str:
-    """
-    Extract text from a PDF and optionally write to a file.
+    """Extract text from a PDF and optionally write to a file.
 
     Parameters
     ----------
     path : str
         Input PDF path.
     output_format : str
-        "text", "markdown", or "json".
+        ``"text"``, ``"markdown"``, or ``"json"``.
     output_path : str, optional
         If given, write output to this file.
     max_pages : int
-        Maximum number of pages to extract (0 = all).
+        Maximum pages to extract (0 = all).
 
     Returns
     -------
     str
-        Extracted text in the requested format.
+        Extracted content in the requested format.
     """
-    extractor = PDFExtractor(path, max_pages=max_pages)
-    result = extractor.extract()
+    result = PDFExtractor(path, max_pages=max_pages).extract()
     if output_format == "json":
-        out = json.dumps(result.to_dict(), indent=2, ensure_ascii=False)
+        out = result.to_json()
     elif output_format == "markdown":
         out = result.to_markdown()
     else:
@@ -343,28 +568,36 @@ def extract_pdf(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def _cli() -> None:
     import argparse
+
     parser = argparse.ArgumentParser(
         prog="pdfextract",
-        description="Extract structured text and metadata from PDF files.",
+        description="Extract text and metadata from PDF files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  python pdfextract.py paper.pdf\n"
+            "  python pdfextract.py paper.pdf -f markdown -o paper.md\n"
+            "  python pdfextract.py paper.pdf -f json -p 5\n"
+        ),
     )
     parser.add_argument("input", help="Path to input PDF file.")
-    parser.add_argument("-o", "--output", default=None, help="Output file path.")
-    parser.add_argument(
-        "-f", "--format",
-        choices=["text", "markdown", "json"],
-        default="text",
-        dest="fmt",
-    )
-    parser.add_argument("-p", "--max-pages", type=int, default=0)
+    parser.add_argument("-o", "--output", default=None, metavar="FILE",
+                        help="Write output to FILE instead of stdout.")
+    parser.add_argument("-f", "--format",
+                        choices=["text", "markdown", "json"],
+                        default="text", dest="fmt", metavar="FORMAT")
+    parser.add_argument("-p", "--max-pages", type=int, default=0, metavar="N",
+                        help="Stop after N pages (0 = all).")
     args = parser.parse_args()
     out = extract_pdf(args.input, output_format=args.fmt,
                       output_path=args.output, max_pages=args.max_pages)
     if not args.output:
         print(out)
     else:
-        print("Written to " + args.output)
+        print(f"Written to {args.output}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfextract"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pure-Python structured text and metadata extractor for PDF files"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -21,7 +21,12 @@ classifiers = [
 ]
 
 [project.scripts]
-pdfextract = "pdfextract:_cli"
+pdfextract     = "pdfextract.cli:main"
+pdfextract-gui = "pdfextract.gui:launch"
 
-[tool.setuptools]
-py-modules = ["pdfextract"]
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths  = ["tests"]
+pythonpath = ["src"]

--- a/src/pdfextract/__init__.py
+++ b/src/pdfextract/__init__.py
@@ -1,17 +1,85 @@
 """
-pdfextract: Structured scientific PDF content extraction tool.
+pdfextract: Pure-Python structured text and metadata extractor for PDF files.
 
-Parses scientific PDF documents and extracts structured content: sections,
-abstracts, figures, tables, captions, equations, citations, and metadata.
-Output is emitted as structured JSON, enabling downstream text mining,
-dataset construction, and reproducible scientific content analysis pipelines.
+Extract text, metadata, and structured output from PDF documents without
+external binaries or native library dependencies.
+
+Basic usage::
+
+    from pdfextract import PDFExtractor, extract_pdf
+
+    # High-level convenience function
+    text = extract_pdf("paper.pdf")
+    markdown = extract_pdf("paper.pdf", output_format="markdown")
+
+    # Full result with per-page data and metadata
+    result = PDFExtractor("paper.pdf").extract()
+    print(result.metadata.get("Title"))
+    for page in result.pages:
+        print(page.page_number, page.word_count)
 """
+from __future__ import annotations
 
-__version__ = "0.1.0"
+from pathlib import Path
+from typing import Optional
+
+from .extractor import PDFExtractor
+from .parser import PDFParseError
+from .schema import ExtractionResult, PageResult
+
+__version__ = "0.2.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .extractor import PDFExtractor
-from .schema import ExtractionResult
 
-__all__ = ["PDFExtractor", "ExtractionResult"]
+def extract_pdf(
+    path: str,
+    output_format: str = "text",
+    output_path: Optional[str] = None,
+    max_pages: int = 0,
+) -> str:
+    """Extract text from a PDF and optionally write the result to a file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the input PDF file.
+    output_format : str
+        ``"text"`` (default), ``"markdown"``, or ``"json"``.
+    output_path : str, optional
+        If given, write output to this file path.
+    max_pages : int
+        Maximum number of pages to extract (``0`` = all pages).
+
+    Returns
+    -------
+    str
+        Extracted content in the requested format.
+
+    Raises
+    ------
+    PDFParseError
+        If the input file is not a valid PDF.
+    """
+    result = PDFExtractor(path, max_pages=max_pages).extract()
+
+    if output_format == "json":
+        out = result.to_json()
+    elif output_format == "markdown":
+        out = result.to_markdown()
+    else:
+        out = result.full_text
+
+    if output_path:
+        Path(output_path).write_text(out, encoding="utf-8")
+
+    return out
+
+
+__all__ = [
+    "PDFExtractor",
+    "PDFParseError",
+    "ExtractionResult",
+    "PageResult",
+    "extract_pdf",
+]

--- a/src/pdfextract/cli.py
+++ b/src/pdfextract/cli.py
@@ -1,0 +1,74 @@
+"""Command-line interface for pdfextract."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .extractor import PDFExtractor
+
+
+def main(argv=None) -> None:
+    """Entry point for the ``pdfextract`` command-line tool."""
+    parser = argparse.ArgumentParser(
+        prog="pdfextract",
+        description="Extract text and metadata from PDF files without external binaries.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  pdfextract paper.pdf\n"
+            "  pdfextract paper.pdf -f markdown -o paper.md\n"
+            "  pdfextract paper.pdf -f json -p 5\n"
+        ),
+    )
+    parser.add_argument("input", help="Path to the input PDF file.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        metavar="FILE",
+        help="Write output to FILE instead of stdout.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["text", "markdown", "json"],
+        default="text",
+        dest="fmt",
+        metavar="FORMAT",
+        help="Output format: text (default), markdown, or json.",
+    )
+    parser.add_argument(
+        "-p",
+        "--max-pages",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Stop after N pages (0 = all pages).",
+    )
+
+    args = parser.parse_args(argv)
+
+    extractor = PDFExtractor(args.input, max_pages=args.max_pages)
+    try:
+        result = extractor.extract()
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.fmt == "json":
+        out = result.to_json()
+    elif args.fmt == "markdown":
+        out = result.to_markdown()
+    else:
+        out = result.full_text
+
+    if args.output:
+        Path(args.output).write_text(out, encoding="utf-8")
+        print(f"Written to {args.output}")
+    else:
+        print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdfextract/extractor.py
+++ b/src/pdfextract/extractor.py
@@ -1,0 +1,216 @@
+"""High-level PDF text and metadata extractor."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Union
+
+from .parser import (
+    PDFParseError,
+    build_xref,
+    dict_get,
+    dict_get_refs,
+    extract_stream_data,
+    extract_text_from_stream,
+    parse_obj,
+    resolve_indirect,
+)
+from .schema import ExtractionResult, PageResult
+
+
+class PDFExtractor:
+    """Extract text and metadata from a PDF file without external binaries.
+
+    Parameters
+    ----------
+    path : str or Path
+        Path to the PDF file.
+    max_pages : int, optional
+        Maximum number of pages to process. ``0`` (default) extracts all pages.
+
+    Examples
+    --------
+    >>> from pdfextract import PDFExtractor
+    >>> result = PDFExtractor("paper.pdf").extract()
+    >>> print(result.word_count)
+    >>> print(result.metadata.get("Title", ""))
+    """
+
+    def __init__(self, path: Union[str, Path], max_pages: int = 0) -> None:
+        self.path = Path(path)
+        self.max_pages = max_pages
+        self._data: bytes = b""
+        self._xref: Dict[int, int] = {}
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        self._data = self.path.read_bytes()
+        if self._data[:4] != b"%PDF":
+            raise PDFParseError(f"Not a PDF file: {self.path}")
+
+    def _get_obj(self, obj_id: int) -> Optional[bytes]:
+        if obj_id not in self._xref:
+            return None
+        try:
+            return parse_obj(self._data, self._xref[obj_id])
+        except PDFParseError:
+            return None
+
+    def _resolve(self, ref: str) -> Optional[bytes]:
+        return resolve_indirect(self._data, self._xref, ref)
+
+    # ------------------------------------------------------------------
+    # Trailer / document catalog
+    # ------------------------------------------------------------------
+
+    def _find_root_ref(self) -> Optional[str]:
+        """Locate the /Root reference from the file trailer or xref stream."""
+        tail = self._data[-4096:].decode("latin-1", errors="replace")
+        m = re.search(r"/Root\s+(\d+\s+\d+\s+R)", tail)
+        if m:
+            return m.group(1)
+        # Fallback: search for an xref stream object that carries /Root
+        for obj_id in self._xref:
+            ob = self._get_obj(obj_id)
+            if ob is None:
+                continue
+            txt = ob.decode("latin-1", errors="replace")
+            if "/Type" in txt and "/XRef" in txt:
+                m = re.search(r"/Root\s+(\d+\s+\d+\s+R)", txt)
+                if m:
+                    return m.group(1)
+        return None
+
+    def _extract_metadata(self) -> Dict[str, str]:
+        """Read the PDF Info dictionary for document-level metadata."""
+        tail = self._data[-4096:].decode("latin-1", errors="replace")
+        info_m = re.search(r"/Info\s+(\d+\s+\d+\s+R)", tail)
+        if not info_m:
+            return {}
+        info_bytes = self._resolve(info_m.group(1))
+        if info_bytes is None:
+            return {}
+
+        metadata: Dict[str, str] = {}
+        for key in ("Title", "Author", "Subject", "Keywords", "Creator", "Producer"):
+            raw = dict_get(info_bytes, key)
+            if raw:
+                if raw.startswith("(") and raw.endswith(")"):
+                    raw = raw[1:-1]
+                metadata[key] = raw.strip()
+        return metadata
+
+    # ------------------------------------------------------------------
+    # Page tree traversal
+    # ------------------------------------------------------------------
+
+    def _iter_pages(self, root_ref: str) -> Iterator[bytes]:
+        """Recursively yield page object bodies in document order."""
+        catalog = self._resolve(root_ref)
+        if catalog is None:
+            return
+        pages_ref = dict_get(catalog, "Pages")
+        if pages_ref and re.search(r"\d+\s+\d+\s+R", pages_ref):
+            yield from self._walk_page_tree(pages_ref)
+
+    def _walk_page_tree(self, node_ref: str) -> Iterator[bytes]:
+        node = self._resolve(node_ref)
+        if node is None:
+            return
+        node_type = dict_get(node, "Type")
+        if node_type == "/Page":
+            yield node
+        else:
+            for kid_ref in dict_get_refs(node, "Kids"):
+                yield from self._walk_page_tree(kid_ref)
+
+    def _fallback_page_scan(self) -> Iterator[bytes]:
+        """Yield page objects found by heuristically scanning all xref entries."""
+        for obj_id in sorted(self._xref):
+            ob = self._get_obj(obj_id)
+            if ob is None:
+                continue
+            txt = ob.decode("latin-1", errors="replace")
+            if "/Type" in txt and "/Page" in txt and "/Pages" not in txt:
+                yield ob
+
+    # ------------------------------------------------------------------
+    # Content stream text extraction
+    # ------------------------------------------------------------------
+
+    def _page_text(self, page_obj: bytes) -> str:
+        """Extract text from a page's content stream(s)."""
+        contents = dict_get(page_obj, "Contents")
+        if contents is None:
+            return ""
+
+        if contents.startswith("["):
+            refs = re.findall(r"\d+\s+\d+\s+R", contents)
+        elif re.search(r"\d+\s+\d+\s+R", contents):
+            refs = [contents]
+        else:
+            return ""
+
+        streams: List[bytes] = []
+        for ref in refs:
+            obj = self._resolve(ref)
+            if obj is not None:
+                sd = extract_stream_data(obj)
+                if sd:
+                    streams.append(sd)
+
+        combined = b"\n".join(streams)
+        return extract_text_from_stream(combined) if combined else ""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def extract(self) -> ExtractionResult:
+        """Run extraction and return an :class:`~pdfextract.schema.ExtractionResult`.
+
+        Raises
+        ------
+        PDFParseError
+            If the file is not a valid PDF.
+
+        Returns
+        -------
+        ExtractionResult
+            Contains per-page text, document metadata, and any non-fatal errors.
+        """
+        self._load()
+        result = ExtractionResult(source=self.path.name, page_count=0)
+        errors: List[str] = []
+
+        try:
+            self._xref = build_xref(self._data)
+        except Exception as exc:
+            result.errors.append(f"xref error: {exc}")
+            return result
+
+        result.metadata = self._extract_metadata()
+
+        root_ref = self._find_root_ref()
+        page_src = (
+            self._iter_pages(root_ref) if root_ref else self._fallback_page_scan()
+        )
+
+        pages: List[PageResult] = []
+        for page_num, page_obj in enumerate(page_src, start=1):
+            try:
+                text = self._page_text(page_obj)
+            except Exception as exc:
+                errors.append(f"page {page_num}: {exc}")
+                text = ""
+            pages.append(PageResult(page_number=page_num, text=text))
+            if self.max_pages and page_num >= self.max_pages:
+                break
+
+        result.pages = pages
+        result.page_count = len(pages)
+        result.errors = errors
+        return result

--- a/src/pdfextract/gui.py
+++ b/src/pdfextract/gui.py
@@ -1,0 +1,215 @@
+"""
+Tkinter-based graphical user interface for pdfextract.
+
+Launch with::
+
+    python -m pdfextract.gui
+
+or via the installed entry point::
+
+    pdfextract-gui
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+try:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+    _HAS_TK = True
+except ImportError:
+    _HAS_TK = False
+
+
+def _require_tk() -> None:
+    if not _HAS_TK:
+        raise RuntimeError(
+            "tkinter is not available.\n"
+            "Install it with your OS package manager, e.g.:\n"
+            "  Debian/Ubuntu: sudo apt install python3-tk\n"
+            "  Fedora:        sudo dnf install python3-tkinter\n"
+            "  macOS (brew):  brew install python-tk"
+        )
+
+
+class _App:
+    """Main application window."""
+
+    def __init__(self, root: "tk.Tk") -> None:
+        self.root = root
+        self.root.title("PDFExtract")
+        self.root.resizable(True, True)
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        outer = {"padx": 8, "pady": 4}
+
+        # ── File selection ──────────────────────────────────────────────
+        file_frame = ttk.LabelFrame(self.root, text="Input PDF")
+        file_frame.pack(fill="x", **outer)
+
+        self._file_var = tk.StringVar()
+        ttk.Entry(file_frame, textvariable=self._file_var, width=60).pack(
+            side="left", fill="x", expand=True, padx=(6, 4), pady=6
+        )
+        ttk.Button(file_frame, text="Browse…", command=self._browse).pack(
+            side="left", padx=(0, 6), pady=6
+        )
+
+        # ── Options ─────────────────────────────────────────────────────
+        opt_frame = ttk.LabelFrame(self.root, text="Options")
+        opt_frame.pack(fill="x", **outer)
+
+        ttk.Label(opt_frame, text="Format:").pack(side="left", padx=(8, 2), pady=6)
+        self._fmt_var = tk.StringVar(value="text")
+        for fmt in ("text", "markdown", "json"):
+            ttk.Radiobutton(
+                opt_frame, text=fmt, variable=self._fmt_var, value=fmt
+            ).pack(side="left", padx=4, pady=6)
+
+        ttk.Separator(opt_frame, orient="vertical").pack(
+            side="left", fill="y", padx=10
+        )
+        ttk.Label(opt_frame, text="Max pages (0 = all):").pack(
+            side="left", padx=(4, 2)
+        )
+        self._max_pages_var = tk.IntVar(value=0)
+        ttk.Spinbox(
+            opt_frame,
+            from_=0,
+            to=9999,
+            textvariable=self._max_pages_var,
+            width=6,
+        ).pack(side="left", padx=(0, 8), pady=6)
+
+        # ── Extract button ───────────────────────────────────────────────
+        btn_frame = ttk.Frame(self.root)
+        btn_frame.pack(fill="x", **outer)
+        self._extract_btn = ttk.Button(
+            btn_frame, text="Extract PDF", command=self._run_extraction
+        )
+        self._extract_btn.pack(fill="x", ipady=4)
+
+        # ── Output area ──────────────────────────────────────────────────
+        out_frame = ttk.LabelFrame(self.root, text="Output")
+        out_frame.pack(fill="both", expand=True, **outer)
+
+        self._output = scrolledtext.ScrolledText(
+            out_frame, wrap="word", font=("Courier", 10), height=22
+        )
+        self._output.pack(fill="both", expand=True, padx=4, pady=4)
+
+        # ── Status bar ───────────────────────────────────────────────────
+        bottom = ttk.Frame(self.root)
+        bottom.pack(fill="x", **outer)
+
+        ttk.Button(bottom, text="Save Output…", command=self._save).pack(side="left")
+        self._status_var = tk.StringVar(value="Ready.")
+        ttk.Label(bottom, textvariable=self._status_var, anchor="w").pack(
+            side="left", fill="x", expand=True, padx=10
+        )
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select a PDF file",
+            filetypes=[("PDF files", "*.pdf"), ("All files", "*.*")],
+        )
+        if path:
+            self._file_var.set(path)
+
+    def _run_extraction(self) -> None:
+        path = self._file_var.get().strip()
+        if not path:
+            messagebox.showwarning("No file", "Please select a PDF file first.")
+            return
+
+        self._extract_btn.state(["disabled"])
+        self._status_var.set("Extracting…")
+        self._output.delete("1.0", "end")
+
+        def _worker() -> None:
+            from .extractor import PDFExtractor
+
+            try:
+                result = PDFExtractor(
+                    path, max_pages=self._max_pages_var.get()
+                ).extract()
+            except Exception as exc:
+                self.root.after(0, self._on_error, str(exc))
+                return
+
+            fmt = self._fmt_var.get()
+            if fmt == "json":
+                text = result.to_json()
+            elif fmt == "markdown":
+                text = result.to_markdown()
+            else:
+                text = result.full_text
+
+            summary = (
+                f"Done — {result.page_count} page(s), {result.word_count} word(s)."
+            )
+            if result.errors:
+                summary += f" [{len(result.errors)} non-fatal error(s)]"
+            self.root.after(0, self._on_done, text, summary)
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _on_done(self, text: str, summary: str) -> None:
+        self._output.insert("1.0", text)
+        self._status_var.set(summary)
+        self._extract_btn.state(["!disabled"])
+
+    def _on_error(self, message: str) -> None:
+        messagebox.showerror("Extraction error", message)
+        self._status_var.set(f"Error: {message}")
+        self._extract_btn.state(["!disabled"])
+
+    def _save(self) -> None:
+        text = self._output.get("1.0", "end").rstrip()
+        if not text:
+            messagebox.showinfo("Nothing to save", "Extract a PDF first.")
+            return
+        ext_map = {"text": ".txt", "markdown": ".md", "json": ".json"}
+        fmt = self._fmt_var.get()
+        path = filedialog.asksaveasfilename(
+            defaultextension=ext_map.get(fmt, ".txt"),
+            filetypes=[
+                ("Text files", "*.txt"),
+                ("Markdown files", "*.md"),
+                ("JSON files", "*.json"),
+                ("All files", "*.*"),
+            ],
+        )
+        if path:
+            Path(path).write_text(text, encoding="utf-8")
+            self._status_var.set(f"Saved to {path}")
+
+
+def launch() -> None:
+    """Launch the PDFExtract GUI application.
+
+    Raises
+    ------
+    RuntimeError
+        If tkinter is not available on this system.
+    """
+    _require_tk()
+    root = tk.Tk()
+    root.geometry("720x620")
+    _App(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    launch()

--- a/src/pdfextract/parser.py
+++ b/src/pdfextract/parser.py
@@ -1,0 +1,398 @@
+"""
+Low-level PDF parsing primitives.
+
+Supports:
+- Classic cross-reference tables (PDF 1.x)
+- Cross-reference streams (PDF 1.5+, FlateDecode)
+- FlateDecode stream decompression
+- BT/ET content-stream text extraction with Tj and TJ operators
+- Octal and common escape sequences in PDF literal strings
+"""
+from __future__ import annotations
+
+import re
+import zlib
+from typing import Dict, List, Optional, Tuple
+
+
+class PDFParseError(Exception):
+    """Raised when a structural error prevents PDF parsing."""
+
+
+# ---------------------------------------------------------------------------
+# Decompression
+# ---------------------------------------------------------------------------
+
+
+def decode_flate(raw: bytes) -> bytes:
+    """Decompress FlateDecode (zlib/deflate) data, tolerating minor errors."""
+    try:
+        return zlib.decompress(raw)
+    except zlib.error:
+        try:
+            return zlib.decompress(raw, -15)  # raw deflate without zlib header
+        except zlib.error:
+            return raw  # return compressed bytes unchanged if both attempts fail
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference parsing
+# ---------------------------------------------------------------------------
+
+
+def find_xref_offset(data: bytes) -> int:
+    """Return the byte offset of the last cross-reference section."""
+    tail = data[-2048:]
+    m = re.search(rb"startxref\s+(\d+)", tail)
+    if not m:
+        raise PDFParseError("startxref not found in file")
+    return int(m.group(1))
+
+
+def _parse_xref_table(
+    data: bytes, offset: int
+) -> Tuple[Dict[int, int], Optional[int]]:
+    """Parse a classic cross-reference table.
+
+    Returns
+    -------
+    tuple
+        ({obj_id: byte_offset}, prev_xref_offset_or_None)
+    """
+    offsets: Dict[int, int] = {}
+    chunk = data[offset : offset + max(131072, len(data) - offset)]
+    text = chunk.decode("latin-1", errors="replace")
+    lines = text.splitlines()
+
+    i = 0
+    if i < len(lines) and lines[i].strip().lower() == "xref":
+        i += 1
+
+    while i < len(lines):
+        m = re.match(r"^(\d+)\s+(\d+)$", lines[i].strip())
+        if not m:
+            break
+        first_obj, count = int(m.group(1)), int(m.group(2))
+        i += 1
+        for j in range(count):
+            if i >= len(lines):
+                break
+            parts = lines[i].strip().split()
+            i += 1
+            if len(parts) >= 3 and parts[2] == "n":
+                try:
+                    offsets[first_obj + j] = int(parts[0])
+                except ValueError:
+                    pass
+
+    trailer_text = "\n".join(lines[i : i + 60])
+    prev_m = re.search(r"/Prev\s+(\d+)", trailer_text)
+    prev = int(prev_m.group(1)) if prev_m else None
+    return offsets, prev
+
+
+def _parse_xref_stream(
+    data: bytes, offset: int
+) -> Tuple[Dict[int, int], Optional[int]]:
+    """Parse a cross-reference stream object (PDF 1.5+).
+
+    Returns
+    -------
+    tuple
+        ({obj_id: byte_offset}, prev_xref_offset_or_None)
+    """
+    chunk = data[offset : offset + 131072]
+
+    stream_m = re.search(rb"stream\r?\n", chunk)
+    if not stream_m:
+        raise PDFParseError("xref stream: 'stream' keyword not found")
+
+    header = chunk[: stream_m.start()].decode("latin-1", errors="replace")
+
+    w_m = re.search(r"/W\s*\[\s*([\d\s]+?)\s*\]", header)
+    if not w_m:
+        raise PDFParseError("xref stream: /W entry missing")
+    widths = [int(x) for x in w_m.group(1).split()]
+    if len(widths) != 3:
+        raise PDFParseError(
+            f"xref stream: /W must have 3 entries, got {len(widths)}"
+        )
+    entry_size = sum(widths)
+    if entry_size == 0:
+        return {}, None
+
+    size_m = re.search(r"/Size\s+(\d+)", header)
+    total_size = int(size_m.group(1)) if size_m else 0
+
+    index_m = re.search(r"/Index\s*\[\s*([\d\s]+?)\s*\]", header)
+    if index_m:
+        idx = [int(x) for x in index_m.group(1).split()]
+        index_pairs = [(idx[k], idx[k + 1]) for k in range(0, len(idx) - 1, 2)]
+    else:
+        index_pairs = [(0, total_size)]
+
+    prev_m = re.search(r"/Prev\s+(\d+)", header)
+    prev = int(prev_m.group(1)) if prev_m else None
+
+    body_start = stream_m.end()
+    end_m = re.search(rb"endstream", chunk[body_start:])
+    raw = chunk[
+        body_start : body_start + (end_m.start() if end_m else len(chunk) - body_start)
+    ]
+    if b"FlateDecode" in chunk[: stream_m.start()]:
+        raw = decode_flate(raw)
+
+    offsets: Dict[int, int] = {}
+    pos = 0
+    w0, w1, _w2 = widths
+
+    def _rd(buf: bytes, width: int, default: int = 0) -> int:
+        return default if width == 0 else int.from_bytes(buf[:width], "big")
+
+    for first_obj, count in index_pairs:
+        for j in range(count):
+            if pos + entry_size > len(raw):
+                break
+            entry = raw[pos : pos + entry_size]
+            pos += entry_size
+            ftype = _rd(entry, w0, default=1)
+            f1 = _rd(entry[w0:], w1)
+            if ftype == 1:  # uncompressed object at byte offset f1
+                offsets[first_obj + j] = f1
+            # ftype == 2 means object is in a compressed ObjStm — not yet supported
+
+    return offsets, prev
+
+
+def build_xref(data: bytes) -> Dict[int, int]:
+    """Build the complete cross-reference table, following /Prev chains.
+
+    Tries the standard xref first; falls back to a linear byte-scan when the
+    xref section is missing or unparseable.
+
+    Parameters
+    ----------
+    data : bytes
+        Raw PDF file bytes.
+
+    Returns
+    -------
+    dict
+        Mapping of object ID → byte offset.
+    """
+    try:
+        offset: Optional[int] = find_xref_offset(data)
+    except PDFParseError:
+        return _scan_objects(data)
+
+    visited: set = set()
+    combined: Dict[int, int] = {}
+
+    while offset is not None and offset not in visited:
+        visited.add(offset)
+        head = data[offset : offset + 16].lstrip()
+        try:
+            if head.startswith(b"xref"):
+                section, prev = _parse_xref_table(data, offset)
+            else:
+                section, prev = _parse_xref_stream(data, offset)
+        except (PDFParseError, Exception):
+            break
+        for obj_id, byte_off in section.items():
+            combined.setdefault(obj_id, byte_off)
+        offset = prev  # type: ignore[assignment]
+
+    return combined or _scan_objects(data)
+
+
+def _scan_objects(data: bytes) -> Dict[int, int]:
+    """Fallback: scan raw bytes for indirect-object markers ``N G obj``."""
+    offsets: Dict[int, int] = {}
+    for m in re.finditer(rb"(?<!\d)(\d+)\s+\d+\s+obj\b", data):
+        obj_id = int(m.group(1))
+        offsets.setdefault(obj_id, m.start())
+    return offsets
+
+
+# ---------------------------------------------------------------------------
+# Object parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_obj(data: bytes, byte_off: int) -> bytes:
+    """Return the raw body bytes of the indirect object at *byte_off*."""
+    window = data[byte_off : byte_off + 131072]
+    m = re.search(rb"\d+\s+\d+\s+obj", window)
+    if not m:
+        raise PDFParseError(f"obj marker not found at offset {byte_off}")
+    body_start = m.end()
+    end_m = re.search(rb"endobj", window[body_start:])
+    return window[
+        body_start : body_start + (end_m.start() if end_m else len(window) - body_start)
+    ]
+
+
+def extract_stream_data(obj_bytes: bytes) -> Optional[bytes]:
+    """Extract and decompress stream data from an object body.
+
+    Returns *None* when the object contains no stream.
+    """
+    sm = re.search(rb"stream\r?\n", obj_bytes)
+    if not sm:
+        return None
+    body_start = sm.end()
+    end_m = re.search(rb"endstream", obj_bytes[body_start:])
+    raw = obj_bytes[
+        body_start : body_start + (end_m.start() if end_m else len(obj_bytes))
+    ]
+    if b"FlateDecode" in obj_bytes[: sm.start()]:
+        raw = decode_flate(raw)
+    return raw
+
+
+def resolve_indirect(
+    data: bytes, xref: Dict[int, int], ref: str
+) -> Optional[bytes]:
+    """Resolve an indirect reference string such as ``'5 0 R'``.
+
+    Returns the raw object body bytes, or *None* if unresolvable.
+    """
+    m = re.fullmatch(r"\s*(\d+)\s+\d+\s+R\s*", ref)
+    if not m:
+        return None
+    obj_id = int(m.group(1))
+    if obj_id not in xref:
+        return None
+    try:
+        return parse_obj(data, xref[obj_id])
+    except PDFParseError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dictionary helpers
+# ---------------------------------------------------------------------------
+
+
+def dict_get(obj_bytes: bytes, key: str) -> Optional[str]:
+    """Return the raw string value for *key* in a PDF dictionary object.
+
+    Handles direct values, indirect references, arrays, and literal strings.
+    Returns *None* when the key is absent.
+    """
+    text = obj_bytes.decode("latin-1", errors="replace")
+    pattern = (
+        r"/" + re.escape(key) + r"\s+"
+        r"(/\w+|<[^>]*>|\[[^\]]*\]|\([^)]*\)|-?\d+(?:\s+\d+\s+R)?|\d+(?:\.\d+)?)"
+    )
+    m = re.search(pattern, text, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+def dict_get_refs(obj_bytes: bytes, key: str) -> List[str]:
+    """Return all indirect references found in the value of *key*.
+
+    Useful for array-valued keys such as ``/Kids``.
+    """
+    raw = dict_get(obj_bytes, key)
+    if raw is None:
+        return []
+    return re.findall(r"\d+\s+\d+\s+R", raw)
+
+
+# ---------------------------------------------------------------------------
+# PDF literal string decoding
+# ---------------------------------------------------------------------------
+
+
+def decode_pdf_string(raw: bytes) -> str:
+    """Decode a PDF literal string, handling octal escapes and common sequences.
+
+    Parameters
+    ----------
+    raw : bytes
+        String contents *without* the surrounding parentheses.
+
+    Returns
+    -------
+    str
+        Decoded Unicode string (using latin-1 for bytes above 127).
+    """
+    out: List[str] = []
+    i = 0
+    n = len(raw)
+    while i < n:
+        b = raw[i]
+        if b == ord("\\"):
+            i += 1
+            if i >= n:
+                break
+            esc = raw[i]
+            if esc == ord("n"):
+                out.append("\n")
+                i += 1
+            elif esc == ord("r"):
+                out.append("\r")
+                i += 1
+            elif esc == ord("t"):
+                out.append("\t")
+                i += 1
+            elif esc in (ord("("), ord(")"), ord("\\")):
+                out.append(chr(esc))
+                i += 1
+            elif ord("0") <= esc <= ord("7"):
+                # 1–3 octal digits
+                j, octal = i, ""
+                while j < n and j < i + 3 and ord("0") <= raw[j] <= ord("7"):
+                    octal += chr(raw[j])
+                    j += 1
+                try:
+                    out.append(chr(int(octal, 8)))
+                except (ValueError, OverflowError):
+                    pass
+                i = j
+            else:
+                out.append(chr(esc))
+                i += 1
+        else:
+            out.append(chr(b) if b < 128 else raw[i : i + 1].decode("latin-1"))
+            i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Text extraction from content streams
+# ---------------------------------------------------------------------------
+
+_BT_ET_RE = re.compile(rb"BT(.+?)ET", re.DOTALL)
+_STR_RE = re.compile(rb"\((?:[^)\\]|\\.)*\)")
+
+
+def extract_text_from_stream(stream: bytes) -> str:
+    """Extract text from a PDF content stream by processing BT/ET blocks.
+
+    Handles both ``(text) Tj`` and ``[(text) kern ...] TJ`` operators.
+
+    Parameters
+    ----------
+    stream : bytes
+        Raw (decompressed) content stream bytes.
+
+    Returns
+    -------
+    str
+        Space-joined text tokens in stream order.
+    """
+    parts: List[str] = []
+    for bt in _BT_ET_RE.finditer(stream):
+        block = bt.group(1)
+        for sm in _STR_RE.finditer(block):
+            text = decode_pdf_string(sm.group(0)[1:-1])
+            if text.strip():
+                parts.append(text.strip())
+        for tj in re.finditer(rb"\[([^\]]+)\]\s*TJ", block):
+            for sm in _STR_RE.finditer(tj.group(1)):
+                text = decode_pdf_string(sm.group(0)[1:-1])
+                if text.strip():
+                    parts.append(text.strip())
+    return " ".join(parts)

--- a/src/pdfextract/schema.py
+++ b/src/pdfextract/schema.py
@@ -1,0 +1,99 @@
+"""Data classes representing PDF extraction results."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class PageResult:
+    """Extracted content from a single PDF page.
+
+    Parameters
+    ----------
+    page_number : int
+        1-based page index.
+    text : str
+        Extracted plain text for this page.
+    """
+
+    page_number: int
+    text: str
+    word_count: int = field(init=False)
+    char_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.word_count = len(self.text.split())
+        self.char_count = len(self.text)
+
+
+@dataclass
+class ExtractionResult:
+    """Full extraction result for a PDF document.
+
+    Parameters
+    ----------
+    source : str
+        Filename or path of the source PDF.
+    page_count : int
+        Number of pages processed.
+    pages : list of PageResult
+        Per-page extraction results.
+    metadata : dict
+        Document metadata from the PDF Info dictionary
+        (e.g. Title, Author, Subject, Keywords).
+    errors : list of str
+        Non-fatal errors encountered during extraction.
+    """
+
+    source: str
+    page_count: int
+    pages: List[PageResult] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def full_text(self) -> str:
+        """Concatenated text of all pages, separated by double newlines."""
+        return "\n\n".join(p.text for p in self.pages if p.text.strip())
+
+    @property
+    def word_count(self) -> int:
+        """Total word count across all pages."""
+        return sum(p.word_count for p in self.pages)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a plain dictionary."""
+        return {
+            "source": self.source,
+            "page_count": self.page_count,
+            "word_count": self.word_count,
+            "metadata": self.metadata,
+            "errors": self.errors,
+            "pages": [
+                {"page": p.page_number, "text": p.text, "words": p.word_count}
+                for p in self.pages
+            ],
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent, ensure_ascii=False)
+
+    def to_markdown(self) -> str:
+        """Render as a Markdown document."""
+        lines: List[str] = [
+            f"# Extracted Text: {self.source}",
+            "",
+            f"**Pages**: {self.page_count} | **Words**: {self.word_count}",
+            "",
+        ]
+        if self.metadata:
+            lines += ["## Metadata", ""]
+            for key, val in self.metadata.items():
+                lines.append(f"- **{key}**: {val}")
+            lines.append("")
+        for page in self.pages:
+            lines += [f"## Page {page.page_number}", "", page.text, ""]
+        return "\n".join(lines)

--- a/tests/test_pdfextract.py
+++ b/tests/test_pdfextract.py
@@ -1,18 +1,381 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""
+Tests for pdfextract.
 
-def test_import():
-    import pdfextract
-    assert hasattr(pdfextract, 'extract_pdf')
+Covers:
+- Public API surface and version string
+- PageResult and ExtractionResult data-model behaviour
+- PDF literal-string decoding (octal escapes, common sequences)
+- Content-stream text extraction (Tj and TJ operators)
+- Cross-reference table parsing and the scan fallback
+- Integration with a synthetically generated minimal valid PDF
+- CLI argument parsing
+"""
+from __future__ import annotations
 
-def test_pdf_parse_error():
-    import pdfextract
-    assert hasattr(pdfextract, 'PDFParseError')
+import json
+import sys
+from pathlib import Path
 
-def test_page_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'PageResult')
+import pytest
 
-def test_extraction_result():
-    import pdfextract
-    assert hasattr(pdfextract, 'ExtractionResult')
+# Allow running without an installed package (src layout)
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import pdfextract
+from pdfextract import ExtractionResult, PageResult, PDFExtractor, PDFParseError, extract_pdf
+from pdfextract.parser import (
+    build_xref,
+    decode_pdf_string,
+    extract_text_from_stream,
+    find_xref_offset,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal-PDF factory
+# ---------------------------------------------------------------------------
+
+
+def _build_minimal_pdf(text: str = "Hello World") -> bytes:
+    """Build a syntactically valid single-page PDF in memory for testing."""
+    content = f"BT /F1 12 Tf 100 700 Td ({text}) Tj ET\n".encode()
+
+    obj1 = b"<</Type /Catalog /Pages 2 0 R>>"
+    obj2 = b"<</Type /Pages /Kids [3 0 R] /Count 1>>"
+    obj3 = (
+        b"<</Type /Page /MediaBox [0 0 612 792]"
+        b" /Contents 4 0 R /Parent 2 0 R>>"
+    )
+    obj4 = (
+        b"<</Length " + str(len(content)).encode() + b">>\n"
+        b"stream\n" + content + b"\nendstream"
+    )
+
+    header = b"%PDF-1.4\n"
+    parts: list = [header]
+    offsets: dict = {}
+
+    for idx, body in enumerate([obj1, obj2, obj3, obj4], start=1):
+        offsets[idx] = len(b"".join(parts))
+        parts.append(f"{idx} 0 obj\n".encode() + body + b"\nendobj\n")
+
+    xref_offset = len(b"".join(parts))
+    xref = b"xref\n0 5\n0000000000 65535 f\r\n"
+    for idx in range(1, 5):
+        xref += f"{offsets[idx]:010d} 00000 n\r\n".encode()
+    parts.append(xref)
+    parts.append(
+        b"trailer\n<</Size 5 /Root 1 0 R>>\nstartxref\n"
+        + str(xref_offset).encode()
+        + b"\n%%EOF\n"
+    )
+    return b"".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+
+class TestPublicAPI:
+    def test_extract_pdf_callable(self):
+        assert callable(pdfextract.extract_pdf)
+
+    def test_required_public_names(self):
+        for name in ("PDFExtractor", "PDFParseError", "ExtractionResult", "PageResult"):
+            assert hasattr(pdfextract, name), f"Missing public name: {name}"
+
+    def test_version_is_nonempty_string(self):
+        assert isinstance(pdfextract.__version__, str)
+        assert pdfextract.__version__
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class TestPageResult:
+    def test_word_count(self):
+        assert PageResult(page_number=1, text="foo bar baz").word_count == 3
+
+    def test_char_count(self):
+        assert PageResult(page_number=1, text="hello").char_count == 5
+
+    def test_empty_text(self):
+        pr = PageResult(page_number=1, text="")
+        assert pr.word_count == 0
+        assert pr.char_count == 0
+
+
+class TestExtractionResult:
+    @pytest.fixture
+    def result(self):
+        return ExtractionResult(
+            source="test.pdf",
+            page_count=2,
+            pages=[
+                PageResult(page_number=1, text="foo bar"),
+                PageResult(page_number=2, text="baz"),
+            ],
+            metadata={"Title": "Demo Paper", "Author": "J. Doe"},
+        )
+
+    def test_full_text_joins_pages(self, result):
+        ft = result.full_text
+        assert "foo bar" in ft
+        assert "baz" in ft
+
+    def test_full_text_skips_blank_pages(self):
+        er = ExtractionResult(
+            source="x.pdf",
+            page_count=2,
+            pages=[
+                PageResult(page_number=1, text="   "),
+                PageResult(page_number=2, text="real"),
+            ],
+        )
+        assert er.full_text == "real"
+
+    def test_word_count_sum(self, result):
+        assert result.word_count == 3  # "foo bar" + "baz"
+
+    def test_to_dict_structure(self, result):
+        d = result.to_dict()
+        assert d["source"] == "test.pdf"
+        assert d["page_count"] == 2
+        assert len(d["pages"]) == 2
+        assert d["metadata"]["Title"] == "Demo Paper"
+
+    def test_to_json_round_trips(self, result):
+        d = json.loads(result.to_json())
+        assert d["source"] == "test.pdf"
+        assert d["word_count"] == 3
+
+    def test_to_markdown_contains_page_headers(self, result):
+        md = result.to_markdown()
+        assert "## Page 1" in md
+        assert "## Page 2" in md
+
+    def test_to_markdown_contains_metadata(self, result):
+        md = result.to_markdown()
+        assert "## Metadata" in md
+        assert "**Title**" in md
+        assert "Demo Paper" in md
+
+    def test_errors_field_defaults_empty(self):
+        er = ExtractionResult(source="f.pdf", page_count=0)
+        assert er.errors == []
+
+
+# ---------------------------------------------------------------------------
+# PDF literal string decoding
+# ---------------------------------------------------------------------------
+
+
+class TestDecodePDFString:
+    def test_plain_ascii(self):
+        assert decode_pdf_string(b"Hello") == "Hello"
+
+    def test_newline_escape(self):
+        assert decode_pdf_string(b"a\\nb") == "a\nb"
+
+    def test_tab_escape(self):
+        assert decode_pdf_string(b"a\\tb") == "a\tb"
+
+    def test_paren_escapes(self):
+        assert decode_pdf_string(b"\\(ok\\)") == "(ok)"
+
+    def test_backslash_escape(self):
+        assert decode_pdf_string(b"a\\\\b") == "a\\b"
+
+    def test_three_digit_octal(self):
+        # \110\145\154\154\157 == "Hello"
+        assert decode_pdf_string(b"\\110\\145\\154\\154\\157") == "Hello"
+
+    def test_one_digit_octal(self):
+        assert decode_pdf_string(b"\\7") == "\x07"
+
+    def test_two_digit_octal(self):
+        assert decode_pdf_string(b"\\40") == " "
+
+    def test_unknown_escape_passthrough(self):
+        # Unknown escape: \z → 'z'
+        assert decode_pdf_string(b"\\z") == "z"
+
+    def test_empty_string(self):
+        assert decode_pdf_string(b"") == ""
+
+
+# ---------------------------------------------------------------------------
+# Content-stream text extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromStream:
+    def test_simple_tj(self):
+        assert "Hello World" in extract_text_from_stream(b"BT (Hello World) Tj ET")
+
+    def test_tj_array(self):
+        result = extract_text_from_stream(b"BT [(Foo) 0 (Bar)] TJ ET")
+        assert "Foo" in result
+        assert "Bar" in result
+
+    def test_ignores_content_outside_bt_et(self):
+        assert extract_text_from_stream(b"(text) Tj") == ""
+
+    def test_multiple_bt_et_blocks(self):
+        stream = b"BT (First) Tj ET some-ops BT (Second) Tj ET"
+        result = extract_text_from_stream(stream)
+        assert "First" in result
+        assert "Second" in result
+
+    def test_empty_stream(self):
+        assert extract_text_from_stream(b"") == ""
+
+    def test_strips_whitespace_tokens(self):
+        result = extract_text_from_stream(b"BT (  ) Tj ET")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference parsing
+# ---------------------------------------------------------------------------
+
+
+class TestXref:
+    def test_find_xref_offset(self):
+        data = b"... startxref\n12345\n%%EOF"
+        assert find_xref_offset(data) == 12345
+
+    def test_find_xref_offset_missing_raises(self):
+        with pytest.raises(PDFParseError):
+            find_xref_offset(b"no startxref here")
+
+    def test_build_xref_scan_fallback(self):
+        # No valid xref table — fallback scan locates the object
+        data = b"%PDF-1.4\n1 0 obj\n<</Type /Catalog>>\nendobj\nstartxref\n999\n%%EOF"
+        xref = build_xref(data)
+        assert 1 in xref
+
+    def test_build_xref_classic_table(self, tmp_path):
+        pdf_bytes = _build_minimal_pdf()
+        xref = build_xref(pdf_bytes)
+        # Objects 1–4 should be present
+        for obj_id in range(1, 5):
+            assert obj_id in xref, f"Object {obj_id} missing from xref"
+
+
+# ---------------------------------------------------------------------------
+# Integration: minimal PDF round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMinimalPDF:
+    def test_returns_extraction_result(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf("Hello JOSS"))
+        result = PDFExtractor(str(pdf_file)).extract()
+        assert isinstance(result, ExtractionResult)
+
+    def test_page_count_is_one(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        result = PDFExtractor(str(pdf_file)).extract()
+        assert result.page_count == 1
+
+    def test_text_extracted(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf("JOSS review"))
+        result = PDFExtractor(str(pdf_file)).extract()
+        assert "JOSS review" in result.full_text
+
+    def test_max_pages_limits_output(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        result = PDFExtractor(str(pdf_file), max_pages=1).extract()
+        assert result.page_count <= 1
+
+    def test_non_pdf_raises_parse_error(self, tmp_path):
+        bad = tmp_path / "bad.pdf"
+        bad.write_bytes(b"this is not a pdf")
+        with pytest.raises(PDFParseError):
+            PDFExtractor(str(bad)).extract()
+
+    def test_extract_pdf_text_format(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf("plain text"))
+        out = extract_pdf(str(pdf_file), output_format="text")
+        assert isinstance(out, str)
+
+    def test_extract_pdf_json_format(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        out = extract_pdf(str(pdf_file), output_format="json")
+        d = json.loads(out)
+        assert "pages" in d
+        assert "source" in d
+
+    def test_extract_pdf_markdown_format(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        out = extract_pdf(str(pdf_file), output_format="markdown")
+        assert "## Page" in out
+
+    def test_extract_pdf_writes_output_file(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        out_file = tmp_path / "out.txt"
+        extract_pdf(str(pdf_file), output_path=str(out_file))
+        assert out_file.exists()
+        assert out_file.read_text(encoding="utf-8") is not None
+
+    def test_errors_list_is_empty_on_valid_pdf(self, tmp_path):
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        result = PDFExtractor(str(pdf_file)).extract()
+        assert result.errors == []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_main_is_callable(self):
+        from pdfextract.cli import main
+        assert callable(main)
+
+    def test_help_exits_zero(self, capsys):
+        from pdfextract.cli import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "pdfextract" in out.lower()
+
+    def test_text_output(self, tmp_path, capsys):
+        from pdfextract.cli import main
+        pdf_file = tmp_path / "t.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf("cli test"))
+        main([str(pdf_file)])
+        out = capsys.readouterr().out
+        assert "cli test" in out
+
+    def test_json_output(self, tmp_path, capsys):
+        from pdfextract.cli import main
+        pdf_file = tmp_path / "t.pdf"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        main([str(pdf_file), "-f", "json"])
+        out = capsys.readouterr().out
+        d = json.loads(out)
+        assert "pages" in d
+
+    def test_write_to_file(self, tmp_path):
+        from pdfextract.cli import main
+        pdf_file = tmp_path / "t.pdf"
+        out_file = tmp_path / "out.txt"
+        pdf_file.write_bytes(_build_minimal_pdf())
+        main([str(pdf_file), "-o", str(out_file)])
+        assert out_file.exists()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fixes in the parser** — octal escape decoding now handles 1–3 digit sequences (was always consuming exactly 3); `OverflowError` from out-of-range values is caught; `src/pdfextract/__init__.py` now imports from modules that actually exist
- **PDF 1.5+ cross-reference streams** — the most common format for modern PDFs was not supported at all; now parses `/Type /XRef` objects with FlateDecode decompression and `/W` field-width decoding; follows `/Prev` chains for incremental updates; falls back to a linear byte-scan for malformed files
- **Correct page ordering** — replaced the fragile heuristic scan for `/Type /Page` objects with proper recursive page-tree traversal starting from the document catalog (`/Root` → `/Pages`)
- **Metadata extraction** — reads Title, Author, Subject, Keywords, Creator, and Producer from the PDF Info dictionary
- **Tkinter GUI** — new `src/pdfextract/gui.py` module with a `pdfextract-gui` entry point; runs extraction in a background thread; supports all three output formats and file save
- **Package restructuring** — proper `src/` layout with separate modules (`parser`, `schema`, `extractor`, `cli`, `gui`); `pyproject.toml` updated with `tool.setuptools.packages.find` and `tool.pytest.ini_options`
- **Tests** — 49 tests (up from 4 attribute-only checks) covering parser primitives, data-model behaviour, string decoding, CLI, and a synthetically generated minimal valid PDF
- **paper.md corrected** — removed false claims about pdfminer.six, camelot, and figure detection; accurate description of the pure-Python implementation
- **README rewritten** — installation, CLI usage, Python API, JSON schema, known limitations

## Test plan

- [x] All 49 pytest tests pass (`pytest tests/ -v`)
- [x] `python pdfextract.py --help` works from repo root
- [x] `pdfextract-gui` entry point imports without error
- [x] Minimal PDF round-trip: page text correctly extracted, JSON/Markdown/text formats all valid

https://claude.ai/code/session_01TppPZfU3v4pByUpUetnN8f
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TppPZfU3v4pByUpUetnN8f)_